### PR TITLE
pip requirements, ensure we're using pandas with 'sort_values’

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests
-pandas
+pandas>=0.17.0


### PR DESCRIPTION
I ran the profit script and it failed. 

Looks like I needed to have pandas 17.0 or above installed. See https://pandas.pydata.org/pandas-docs/version/0.17.0/generated/pandas.DataFrame.sort_values.html. 