### PR TITLE
Fix blank slate crash

### DIFF
--- a/csv-export.py
+++ b/csv-export.py
@@ -35,7 +35,7 @@ robinhood = Robinhood()
 while logged_in != True:
 
     if username == "":
-        username = os.getenv("RH_USERNAME")
+        username = os.getenv("RH_USERNAME", "")
     if username == "":
         print("Robinhood username:", end=' ')
         try:
@@ -45,7 +45,7 @@ while logged_in != True:
         username = input()
 
     if password == "":
-        password = os.getenv("RH_PASSWORD")
+        password = os.getenv("RH_PASSWORD", "")
     if password == "":
         password = getpass.getpass()
 

--- a/csv-export.py
+++ b/csv-export.py
@@ -50,7 +50,7 @@ while logged_in != True:
         password = getpass.getpass()
 
     logged_in = robinhood.login(username=username, password=password)
-    if logged_in != True and logged_in.get('non_field_errors') == None and logged_in['mfa_required'] == True:
+    if logged_in != True and logged_in.get('non_field_errors') == None and logged_in.get('mfa_required') == True:
 
         if mfa_code is None:
             mfa_code = os.getenv("RH_MFA")


### PR DESCRIPTION
First off, thanks for putting this script together! Will save me a lot of time.

When running `csv-export.py` without any prior configuration, I got a `KeyError`:

```
$ python csv-export.py
Traceback (most recent call last):
  File "csv-export.py", line 53, in <module>
    if logged_in != True and logged_in.get('non_field_errors') == None and logged_in['mfa_required'] == True:
KeyError: 'mfa_required'
```

This is because `os.getenv` returns `None` as a default value, overwriting the `""` value we had from `argparse`, meaning we never get to the interactive username/password prompt and instead call `robinhood.login` with `None` as username and password. `login` returns the Robinhood response to this which is: 
```
{u'detail': u'Unable to log in with provided credentials.'}
```

which in turn leads us to throw a `KeyError` because we assume there is a `mfa_required` key if there are no `non_field_errors` in the RH response.

This change ensures that we prompt for username/password when they're not provided in arguments or envvars, and stops the `KeyError` from occurring when the RH response doesn't contain a `mfa_required` key.