### PR TITLE
Quote fields that usually have json data

### DIFF
--- a/csv-export.py
+++ b/csv-export.py
@@ -126,7 +126,10 @@ for row in fields:
         if (idx > 0):
             csv += ","
         try:
-            csv += str(fields[row][key])
+            if key == 'executed_notional' or key == 'last_trail_price' or key == 'dollar_based_amount' or key == 'total_notional':
+                csv += "\""+str(fields[row][key])+"\""
+            else:
+                csv += str(fields[row][key])
         except:
             csv += ""
 


### PR DESCRIPTION
Since some of the fields are JSON, the commas within the JSON will break the CSV fields. This is a quick fix to quote those fields so that the resulting csv file can be opened correctly.