### PR TITLE
Add auth_token argument to allow passing existing OAuth2/JWT token

### DIFF
--- a/Robinhood.py
+++ b/Robinhood.py
@@ -101,6 +101,11 @@ class Robinhood:
         self.headers['Authorization'] = 'Bearer ' + self.auth_token
         return True
 
+    def use_token(self, access_token):
+        self.auth_token = access_token
+        self.headers['Authorization'] = 'Bearer ' + self.auth_token
+        return True
+
     ##############################
     #GET DATA 
     ##############################

--- a/csv-export.py
+++ b/csv-export.py
@@ -24,6 +24,8 @@ parser.add_argument(
 parser.add_argument(
     '--device_token', help='your device token')
 parser.add_argument(
+    '--auth_token', help='your oauth2 token')
+parser.add_argument(
     '--profit', action='store_true', help='calculate profit for each sale')
 parser.add_argument(
     '--dividends', action='store_true', help='export dividend payments')
@@ -32,13 +34,18 @@ username = args.username
 password = args.password
 mfa_code = args.mfa_code
 device_token = args.device_token
+auth_token = args.auth_token
 
 load_dotenv(find_dotenv())
 
 robinhood = Robinhood()
 
 # login to Robinhood
-logged_in = collect_login_data(robinhood_obj=robinhood, username=username, password=password, device_token=device_token, mfa_code=mfa_code)
+if args.auth_token:
+    robinhood.use_token(args.auth_token)
+    logged_in = True
+else:
+    logged_in = collect_login_data(robinhood_obj=robinhood, username=username, password=password, device_token=device_token, mfa_code=mfa_code)
 
 print("Pulling trades. Please wait...")
 


### PR DESCRIPTION
Add an auth_token parameter that let's you bypass the login by supplying a JWT OAuth2 token (eg. from your browser's login).
The parameter is the "access_token" field value in the JSON response to the https://api.robinhood.com/oauth2/token/ request.