### PR TITLE
Add complete Robinhood account CSV exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 RH_USERNAME=example_robinhood_username
 RH_PASSWORD=example_robinhood_password
+RH_ACCESS_TOKEN=
 RH_DEVICE_TOKEN=
 RH_MFA=

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-RH_USERNAME = example_robinhood_username
-RH_PASSWORD = example_robinhood_password
+RH_USERNAME=example_robinhood_username
+RH_PASSWORD=example_robinhood_password
+RH_DEVICE_TOKEN=
+RH_MFA=

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ target/
 !.env.example
 
 robinhood.csv
+exports/
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,10 @@ RH_MFA=your_mfa_code               # optional; prompted if MFA is enabled
 
 Preferred Robinhood auth/export flow:
 
-- If the user is already logged into Robinhood inside a `cmux` browser surface, use the `robinhood-cmux-export` skill and `python export-from-cmux.py --cmux-surface <surface> --dividends --output-dir exports`.
-- Prefer this over manual token copying. The wrapper reads the live browser auth, runs the export, and clears browser auth state after completion unless `--keep-auth` is explicitly requested.
+- If the user is already logged into Robinhood in a normal local browser, prefer the browser-cookie flow over `cmux`.
+- Use `python export-from-browser-cookies.py --browser auto --dividends --wash-sales --output-dir exports`.
+- This reads the Robinhood access token from the local browser cookie store with `browser_cookie3`, runs the export, and avoids depending on `cmux` browser socket stability.
+- Treat `export-from-cmux.py` as a fallback only if browser-cookie extraction is not available.
 
 ## Running the scripts
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,11 @@ RH_DEVICE_TOKEN=your_device_token  # optional; auto-generated if missing
 RH_MFA=your_mfa_code               # optional; prompted if MFA is enabled
 ```
 
+Preferred Robinhood auth/export flow:
+
+- If the user is already logged into Robinhood inside a `cmux` browser surface, use the `robinhood-cmux-export` skill and `python export-from-cmux.py --cmux-surface <surface> --dividends --output-dir exports`.
+- Prefer this over manual token copying. The wrapper reads the live browser auth, runs the export, and clears browser auth state after completion unless `--keep-auth` is explicitly requested.
+
 ## Running the scripts
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+
+Credentials can be provided via `.env` (copy `.env.example`), CLI args, or interactive prompt:
+
+```
+RH_USERNAME=your_username
+RH_PASSWORD=your_password
+RH_DEVICE_TOKEN=your_device_token  # optional; auto-generated if missing
+RH_MFA=your_mfa_code               # optional; prompted if MFA is enabled
+```
+
+## Running the scripts
+
+```bash
+# Export stock trades
+python csv-export.py [--username U] [--password P] [--device_token T] [--mfa_code M] [--debug] [--profit] [--dividends]
+
+# Export options trades
+python csv-options-export.py [--username U] [--password P] [--device_token T] [--mfa_code M] [--debug] [--profit]
+```
+
+Both scripts prompt for a filename at the end (default: `robinhood.csv` / `option-trades.csv`).
+
+## Architecture
+
+The project is a small collection of scripts with no test suite.
+
+- `Robinhood.py` — thin HTTP client wrapping `api.robinhood.com`. Handles OAuth2 login (Bearer token), paginated GET requests via `get_endpoint(name)` / `get_custom_endpoint(url)`, and a handful of quote/order helpers. Supports Python 2/3 via try/except on `urllib`.
+- `login_data.py` — `collect_login_data()` orchestrates credential resolution (env vars → CLI args → interactive prompt → MFA retry loop) and calls `Robinhood.login()`.
+- `csv-export.py` — fetches stock orders (`/orders/`), resolves instrument URLs to ticker symbols (cached in `cached_instruments` dict to reduce API calls), builds a flat `fields` dict keyed by row index, then writes CSV. Optionally exports dividends (`--dividends`) and calculates profit (`--profit`).
+- `csv-options-export.py` — fetches options orders (`/options/orders/`), iterates over legs and executions, fetches contract metadata (strike, expiration, ticker) per leg, and writes CSV.
+- `profit_extractor.py` — reads the exported CSV with pandas, applies FIFO matching of buys to sells, detects basic wash sales (30-day window), and writes a `*_profit.csv` with Profit/Wash Sale/Tax columns.
+
+## Key notes
+
+- The `device_token` is required by Robinhood's API. If not supplied, a UUID is auto-generated — but a consistent token avoids repeated MFA challenges. See README for how to extract yours from browser DevTools.
+- Pagination: both export scripts loop on `orders['next']` until `None`.
+- `csv-options-export.py` has a leftover debug block that always writes `stocks.txt`; this is intentional legacy behavior.
+- `profit_extractor.py` uses `raw_input` / `input` compatibility shim for Python 2/3.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ pip install -r requirements.txt
 
 The scripts accept credentials either interactively or through environment variables.
 
+Safest usage:
+
+- Prefer interactive prompts for your password instead of passing `--password` on the command line.
+- If you want non-interactive runs, copy `.env.example` to `.env` and keep it local. `.env` is ignored by git in this repo.
+- Avoid `--debug` unless you need it, because it writes raw Robinhood API responses to local files.
+
 Supported environment variables:
 
 - `RH_USERNAME`
@@ -40,10 +46,16 @@ Supported environment variables:
 Example:
 
 ```bash
-export RH_USERNAME='your_robinhood_username'
-export RH_PASSWORD='your_robinhood_password'
-export RH_MFA='123456'
-export RH_DEVICE_TOKEN='your_device_token'
+cp .env.example .env
+```
+
+Then edit `.env` with your values:
+
+```bash
+RH_USERNAME=your_robinhood_username
+RH_PASSWORD=your_robinhood_password
+RH_MFA=123456
+RH_DEVICE_TOKEN=your_device_token
 ```
 
 If you do not provide a device token, the login helper generates one automatically. If Robinhood prompts for MFA, the scripts will ask for it unless `RH_MFA` or `--mfa_code` is provided.

--- a/README.md
+++ b/README.md
@@ -84,24 +84,33 @@ Browser token workflow:
 
 When `RH_ACCESS_TOKEN` is set, the scripts try token auth first and only fall back to username/password if the token is rejected.
 
-## Safer cmux Flow
+## Preferred Browser Cookie Flow
 
-If you are logged into Robinhood inside a `cmux` browser surface, use the wrapper below instead of copying tokens by hand:
+If you are already logged into Robinhood in a normal local browser, use the wrapper below instead of copying tokens by hand:
 
 ```bash
-python3 export-from-cmux.py --cmux-surface surface:13 --dividends --output-dir exports
+python3 export-from-browser-cookies.py --browser auto --dividends --wash-sales --output-dir exports
 ```
 
 By default this flow:
 
-- reads the primary Robinhood access token from the logged-in `cmux` browser surface
+- reads the Robinhood access token directly from your local browser cookie store using `browser_cookie3`
+- falls back to reading the active Robinhood browser tab via AppleScript if cookie extraction does not expose the token
 - runs the full export without writing the token into repo files
-- clears Robinhood auth state from that `cmux` browser surface after the export finishes
 - blanks `RH_ACCESS_TOKEN` in `.env` if it was set there
 
-Pass `--keep-auth` only if you intentionally want to stay logged in inside that `cmux` browser surface after export.
+The wrapper does not clear your browser cookies. Log out of Robinhood in the browser when you are done if you want that session closed.
 
-This cleanup does not erase shell history, agent tool logs, or previously approved command prefixes outside the repo.
+Supported values for `--browser` depend on what `browser_cookie3` can read on your machine. Typical options are `chrome`, `brave`, `edge`, `chromium`, `firefox`, `opera`, and `safari`.
+
+If the browser-tab fallback is used on macOS, you may need to:
+
+- approve the Automation permission prompt so Terminal/Codex can control the browser
+- in Chrome, enable `View` -> `Developer` -> `Allow JavaScript from Apple Events`
+
+## cmux Flow
+
+The older `cmux` browser-surface workflow still exists as `export-from-cmux.py`, but it is no longer the preferred path. In practice, the `cmux` browser socket proved less reliable than reading cookies directly from the local browser profile.
 
 ## What Each Script Exports
 
@@ -120,12 +129,20 @@ Default outputs:
 
 This is the wrapper command for users who want the full picture of their Robinhood account in one run. It logs in once, exports stock and options trade history, and exports current stock and options holdings.
 
+If you want this full export without manually copying tokens, prefer:
+
+```bash
+python3 export-from-browser-cookies.py --browser auto --dividends --wash-sales --output-dir exports
+```
+
 Optional flags:
 
 - `--output-dir exports` writes all files into a specific directory
 - `--include-closed` includes zero-quantity positions in the holdings exports
 - `--dividends` also exports `dividends.csv`
 - `--profit` also generates profit CSVs for trade history
+- `--include-non-filled` keeps queued, cancelled, or otherwise non-filled stock orders in `robinhood.csv`
+- `--wash-sales` writes `robinhood_wash_sale_candidates.csv` plus `robinhood_wash_sale_lot_matches.csv`
 - `--debug` saves raw API payloads for each export
 
 ### Stock trade history
@@ -136,13 +153,27 @@ python3 csv-export.py
 
 Default output: `robinhood.csv`
 
-This exports stock order history from the Robinhood `orders` endpoint. Use this when you want buys, sells, execution details, timestamps, and a full trade ledger.
+This exports stock order history from the Robinhood `orders` endpoint. By default it only includes filled orders so the CSV is a cleaner ledger of what actually executed.
 
 Optional flags:
 
 - `--dividends` exports dividend history to `dividends.csv`
 - `--profit` writes an additional profit-oriented CSV
+- `--include-non-filled` keeps queued, cancelled, and other non-filled orders in the stock history export
+- `--wash-sales` writes `robinhood_wash_sale_candidates.csv` and `robinhood_wash_sale_lot_matches.csv`
 - `--debug` saves the raw API payload to `debug.txt`
+
+The stock history CSV is designed for downstream analysis and includes readable columns such as:
+
+- `symbol`
+- `side`
+- `trade_date`
+- `quantity`
+- `filled_quantity`
+- `average_price`
+- `executed_notional_amount`
+- `fees`
+- `position_effect`
 
 ### Options trade history
 
@@ -215,6 +246,22 @@ Or use the wrapper command:
 ```bash
 python3 export-all.py
 ```
+
+## Wash-Sale Screener
+
+If you pass `--wash-sales`, the exporter writes:
+
+- `*_wash_sale_candidates.csv` with one row per loss sale that appears to trigger wash-sale treatment
+- `*_wash_sale_lot_matches.csv` with the replacement-buy lot matches used in that estimate
+
+These are still review reports, not a final tax filing output. They now do more than simple symbol screening:
+
+- loss-bearing sale lots matched against FIFO cost basis
+- replacement buys matched in acquisition order
+- replacement buys within 30 days before or after the loss sale
+- pre-sale replacement shares counted only to the extent they remain held after the loss sale
+
+It is not a final tax report. It still does not account for every edge case across other accounts, spouse activity, IRAs, or all substantially identical instruments.
 
 ## Device Token
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,146 @@
 # Robinhood to CSV
 
-A Python script to export your [Robinhood](https://www.robinhood.com) trades to a .csv file.  Based on the [Robinhood library by Rohan Pai](https://github.com/Jamonek/Robinhood).  Read the back story on my [blog](http://www.onlineaspect.com/2015/12/17/export-robinhood-investments-to-csv).
+Python scripts to export Robinhood data to CSV.
+
+This repo now supports two categories of export:
+
+- Trade history: every stock or options order returned by Robinhood, including closed positions.
+- Current holdings: the positions you currently hold, based on Robinhood's positions endpoints.
+
+The project is based on the Robinhood library by Rohan Pai. Read the back story on the original stock trade exporter on the [blog post](http://www.onlineaspect.com/2015/12/17/export-robinhood-investments-to-csv).
 
 Works on Python 2.7+ and 3.5+
 
-#### Install:
+## Install
+
+```bash
 pip install -r requirements.txt
+```
 
-#### Run:
+Using a virtual environment is recommended:
 
-For exporting stock trades, run:
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
 
-`python csv-export.py`
+## Credentials
 
-For exporting options trades, run:
+The scripts accept credentials either interactively or through environment variables.
 
-`python csv-options-export.py`
+Supported environment variables:
 
+- `RH_USERNAME`
+- `RH_PASSWORD`
+- `RH_DEVICE_TOKEN`
+- `RH_MFA`
 
-For Device_Token go to your browser
+Example:
+
+```bash
+export RH_USERNAME='your_robinhood_username'
+export RH_PASSWORD='your_robinhood_password'
+export RH_MFA='123456'
+export RH_DEVICE_TOKEN='your_device_token'
+```
+
+If you do not provide a device token, the login helper generates one automatically. If Robinhood prompts for MFA, the scripts will ask for it unless `RH_MFA` or `--mfa_code` is provided.
+
+## What Each Script Exports
+
+### Stock trade history
+
+```bash
+python3 csv-export.py
+```
+
+Default output: `robinhood.csv`
+
+This exports stock order history from the Robinhood `orders` endpoint. Use this when you want buys, sells, execution details, timestamps, and a full trade ledger.
+
+Optional flags:
+
+- `--dividends` exports dividend history to `dividends.csv`
+- `--profit` writes an additional profit-oriented CSV
+- `--debug` saves the raw API payload to `debug.txt`
+
+### Options trade history
+
+```bash
+python3 csv-options-export.py
+```
+
+Default output: `option-trades.csv`
+
+This exports options order history from the Robinhood `optionsOrders` endpoint. Use this when you want options trade legs, premiums, and execution details for opened and closed contracts.
+
+Optional flags:
+
+- `--profit` writes an additional profit-oriented CSV
+- `--debug` saves the raw API payload to `debug.txt`
+
+### Current stock holdings
+
+```bash
+python3 csv-holdings-export.py
+```
+
+Default output: `stock-holdings.csv`
+
+This exports stock positions from the Robinhood `positions` endpoint. By default it only keeps open positions with a quantity greater than zero, which makes it a current holdings export rather than a full historical ledger.
+
+Optional flags:
+
+- `--include-closed` keeps zero-quantity positions returned by Robinhood
+- `--debug` saves the raw API payload to `debug-holdings.txt`
+
+### Current options holdings
+
+```bash
+python3 csv-options-holdings-export.py
+```
+
+Default output: `option-holdings.csv`
+
+This exports options positions from the Robinhood `optionsPositions` endpoint. By default it only keeps open positions and enriches each row with contract metadata such as ticker, strike price, expiration date, and option type.
+
+Optional flags:
+
+- `--include-closed` keeps zero-quantity positions returned by Robinhood
+- `--debug` saves the raw API payload to `debug-options-holdings.txt`
+
+## History vs Holdings
+
+Trade history and holdings answer different questions:
+
+- `csv-export.py` and `csv-options-export.py` answer: "What orders have I placed?"
+- `csv-holdings-export.py` and `csv-options-holdings-export.py` answer: "What do I currently hold?"
+
+Example:
+
+- If you bought AAPL in January and sold it in February, trade history will still contain those orders.
+- Current holdings will usually not contain AAPL anymore because the position is closed.
+
+If you want a complete picture of your Robinhood account, run all four scripts:
+
+```bash
+python3 csv-export.py
+python3 csv-options-export.py
+python3 csv-holdings-export.py
+python3 csv-options-holdings-export.py
+```
+
+## Device Token
+
+If you want to reuse Robinhood's browser device token instead of letting the script generate one:
 
     Go to robinhood.com. Log out if you're already logged in
     Right click > Inspect element
     Click on Network tab
-    -Enter "token" in the input line at the top where it says "Filter URLs"
-    With the network monitor-er open, login to Robinhood
-    You'll see two new urls pop up that say "api.robinhood.com" and "/oauth2/token"
-    Click the one that's not 0 bytes in size
-    Click on Headers, then scroll down to the Request Payload section
-    Here, you'll see new JSON parameters for your login. What you'll need here is the device token.
+    Enter "token" in the filter input
+    With the network monitor open, log in to Robinhood
+    You will see requests for "api.robinhood.com" and "/oauth2/token"
+    Click the request that is not 0 bytes in size
+    Click on Headers, then scroll to the Request Payload section
+    Copy the `device_token` value

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Supported environment variables:
 
 - `RH_USERNAME`
 - `RH_PASSWORD`
+- `RH_ACCESS_TOKEN`
 - `RH_DEVICE_TOKEN`
 - `RH_MFA`
 
@@ -54,11 +55,53 @@ Then edit `.env` with your values:
 ```bash
 RH_USERNAME=your_robinhood_username
 RH_PASSWORD=your_robinhood_password
+RH_ACCESS_TOKEN=
 RH_MFA=123456
 RH_DEVICE_TOKEN=your_device_token
 ```
 
 If you do not provide a device token, the login helper generates one automatically. If Robinhood prompts for MFA, the scripts will ask for it unless `RH_MFA` or `--mfa_code` is provided.
+
+## Token Login
+
+Robinhood's password login flow is unstable for unofficial clients. This repo now supports a bearer token flow that skips the blocked OAuth password grant.
+
+You can pass a token either through `RH_ACCESS_TOKEN` in `.env` or `--access-token` on the command line.
+
+Example:
+
+```bash
+python3 export-all.py --access-token 'your_token_here'
+```
+
+Browser token workflow:
+
+1. Log in to Robinhood in your browser.
+2. Open developer tools and go to the `Application` or `Storage` tab.
+3. Find the Robinhood cookies for `robinhood.com`.
+4. Copy the value of `__Host-Web-App-Secondary-Access-Token`.
+5. Put that value into `RH_ACCESS_TOKEN` and rerun the exporter.
+
+When `RH_ACCESS_TOKEN` is set, the scripts try token auth first and only fall back to username/password if the token is rejected.
+
+## Safer cmux Flow
+
+If you are logged into Robinhood inside a `cmux` browser surface, use the wrapper below instead of copying tokens by hand:
+
+```bash
+python3 export-from-cmux.py --cmux-surface surface:13 --dividends --output-dir exports
+```
+
+By default this flow:
+
+- reads the primary Robinhood access token from the logged-in `cmux` browser surface
+- runs the full export without writing the token into repo files
+- clears Robinhood auth state from that `cmux` browser surface after the export finishes
+- blanks `RH_ACCESS_TOKEN` in `.env` if it was set there
+
+Pass `--keep-auth` only if you intentionally want to stay logged in inside that `cmux` browser surface after export.
+
+This cleanup does not erase shell history, agent tool logs, or previously approved command prefixes outside the repo.
 
 ## What Each Script Exports
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repo now supports two categories of export:
 
 - Trade history: every stock or options order returned by Robinhood, including closed positions.
 - Current holdings: the positions you currently hold, based on Robinhood's positions endpoints.
+- Complete account snapshot: one command that exports both history and holdings.
 
 The project is based on the Robinhood library by Rohan Pai. Read the back story on the original stock trade exporter on the [blog post](http://www.onlineaspect.com/2015/12/17/export-robinhood-investments-to-csv).
 
@@ -48,6 +49,29 @@ export RH_DEVICE_TOKEN='your_device_token'
 If you do not provide a device token, the login helper generates one automatically. If Robinhood prompts for MFA, the scripts will ask for it unless `RH_MFA` or `--mfa_code` is provided.
 
 ## What Each Script Exports
+
+### Complete account snapshot
+
+```bash
+python3 export-all.py
+```
+
+Default outputs:
+
+- `robinhood.csv`
+- `option-trades.csv`
+- `stock-holdings.csv`
+- `option-holdings.csv`
+
+This is the wrapper command for users who want the full picture of their Robinhood account in one run. It logs in once, exports stock and options trade history, and exports current stock and options holdings.
+
+Optional flags:
+
+- `--output-dir exports` writes all files into a specific directory
+- `--include-closed` includes zero-quantity positions in the holdings exports
+- `--dividends` also exports `dividends.csv`
+- `--profit` also generates profit CSVs for trade history
+- `--debug` saves raw API payloads for each export
 
 ### Stock trade history
 
@@ -129,6 +153,12 @@ python3 csv-export.py
 python3 csv-options-export.py
 python3 csv-holdings-export.py
 python3 csv-options-holdings-export.py
+```
+
+Or use the wrapper command:
+
+```bash
+python3 export-all.py
 ```
 
 ## Device Token

--- a/Robinhood.py
+++ b/Robinhood.py
@@ -71,23 +71,20 @@ class Robinhood:
         self.password = password
         self.mfa_code = mfa_code
         self.device_token = device_token
+        fields = {
+            'password': self.password,
+            'username': self.username,
+            'grant_type': 'password',
+            'client_id': self.client_id,
+            'device_token': self.device_token,
+            'scope': 'internal',
+            'expires_in': 86400,
+            'try_passkeys': False,
+            'token_request_path': '/login',
+            'create_read_only_secondary_token': True
+        }
         if mfa_code:
-            fields = {
-                'password' : self.password,
-                'username' : self.username,
-                'mfa_code': self.mfa_code,
-                'grant_type': 'password',
-                'client_id': self.client_id,
-                'device_token': self.device_token
-            }
-        else: 
-            fields = {
-                'password' : self.password,
-                'username' : self.username,
-                'grant_type': 'password',
-                'client_id': self.client_id,
-                'device_token':self.device_token
-            }
+            fields['mfa_code'] = self.mfa_code
         try:
             data = urllib.urlencode(fields) #py2
         except:
@@ -100,6 +97,23 @@ class Robinhood:
             return res
         self.headers['Authorization'] = 'Bearer ' + self.auth_token
         return True
+
+    def set_auth_token(self, auth_token):
+        self.auth_token = auth_token.strip()
+        self.headers['Authorization'] = 'Bearer ' + self.auth_token
+        self.session.headers = self.headers
+
+    def validate_auth_token(self):
+        try:
+            res = self.session.get(self.endpoints['user'])
+            data = res.json()
+        except ValueError:
+            return {"detail": "Token validation failed."}
+
+        if res.ok and isinstance(data, dict) and data.get("url"):
+            return True
+
+        return data
 
     ##############################
     #GET DATA 

--- a/browser_cookie_auth.py
+++ b/browser_cookie_auth.py
@@ -1,0 +1,103 @@
+from __future__ import print_function
+
+import os
+
+import browser_cookie3
+from browser_tab_auth import get_browser_tab_access_token
+
+
+PRIMARY_COOKIE_NAMES = [
+    "__Host-Web-App-Secondary-Access-Token",
+    "__Host-Web-App-Access-Token",
+]
+
+
+def _browser_readers():
+    readers = {}
+    for name in ["chrome", "brave", "chromium", "edge", "firefox", "opera", "safari"]:
+        reader = getattr(browser_cookie3, name, None)
+        if reader is not None:
+            readers[name] = reader
+    return readers
+
+
+def available_browsers():
+    return sorted(_browser_readers().keys())
+
+
+def _candidate_browsers(browser_name):
+    readers = _browser_readers()
+    if browser_name and browser_name != "auto":
+        if browser_name not in readers:
+            raise RuntimeError(
+                "Unsupported browser '{}'. Available: {}".format(
+                    browser_name, ", ".join(sorted(readers.keys()))
+                )
+            )
+        return [(browser_name, readers[browser_name])]
+
+    preferred = ["chrome", "brave", "edge", "chromium", "firefox", "opera", "safari"]
+    return [(name, readers[name]) for name in preferred if name in readers]
+
+
+def _cookie_matches(cookie):
+    domain = (cookie.domain or "").lstrip(".")
+    return domain.endswith("robinhood.com")
+
+
+def get_browser_access_token(browser_name="auto"):
+    errors = []
+
+    for name, reader in _candidate_browsers(browser_name):
+        try:
+            cookie_jar = reader(domain_name="robinhood.com")
+        except Exception as exc:
+            errors.append("{}: {}".format(name, exc))
+            continue
+
+        cookies = [cookie for cookie in cookie_jar if _cookie_matches(cookie)]
+        if not cookies:
+            errors.append("{}: no Robinhood cookies found".format(name))
+            continue
+
+        for cookie_name in PRIMARY_COOKIE_NAMES:
+            for cookie in cookies:
+                if cookie.name == cookie_name and cookie.value:
+                    return cookie.value.strip(), name
+
+        for cookie in cookies:
+            if "Access-Token" in cookie.name and cookie.value:
+                return cookie.value.strip(), name
+
+        errors.append("{}: Robinhood cookies found, but no access token cookie matched".format(name))
+
+    try:
+        return get_browser_tab_access_token()
+    except Exception as exc:
+        errors.append("browser tab automation: {}".format(exc))
+
+    raise RuntimeError("Unable to read a Robinhood browser access token. {}".format(" | ".join(errors)))
+
+
+def clear_env_access_token(env_path):
+    if not env_path or not os.path.exists(env_path):
+        return False
+
+    with open(env_path, "r") as infile:
+        lines = infile.readlines()
+
+    updated_lines = []
+    changed = False
+    for line in lines:
+        if line.startswith("RH_ACCESS_TOKEN="):
+            updated_lines.append("RH_ACCESS_TOKEN=\n")
+            changed = True
+        else:
+            updated_lines.append(line)
+
+    if not changed:
+        return False
+
+    with open(env_path, "w") as outfile:
+        outfile.writelines(updated_lines)
+    return True

--- a/browser_tab_auth.py
+++ b/browser_tab_auth.py
@@ -1,0 +1,138 @@
+from __future__ import print_function
+
+import json
+import subprocess
+
+
+BROWSER_APPS = [
+    "Google Chrome",
+    "Arc",
+    "Brave Browser",
+    "Microsoft Edge",
+]
+
+
+def run_osascript(lines):
+    command = ["osascript"]
+    for line in lines:
+        command.extend(["-e", line])
+
+    result = subprocess.run(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "osascript failed"
+        raise RuntimeError(message)
+    return result.stdout.strip()
+
+
+def _normalize_result(value):
+    value = value.strip()
+    if value in ("", "null", "undefined"):
+        return ""
+    if value.startswith('"') and value.endswith('"'):
+        try:
+            return json.loads(value)
+        except ValueError:
+            return value[1:-1]
+    return value
+
+
+def get_active_browser_origin(app_name):
+    return _normalize_result(
+        run_osascript(
+            [
+                'with timeout of 5 seconds',
+                'tell application "{}" to execute active tab of front window javascript "window.location.origin"'.format(app_name),
+                'end timeout',
+            ]
+        )
+    )
+
+
+def read_active_browser_script(app_name, script):
+    return _normalize_result(
+        run_osascript(
+            [
+                'with timeout of 5 seconds',
+                'tell application "{}" to execute active tab of front window javascript "{}"'.format(
+                    app_name, script.replace("\\", "\\\\").replace('"', '\\"')
+                ),
+                'end timeout',
+            ]
+        )
+    )
+
+
+def get_browser_tab_access_token():
+    errors = []
+
+    scripts = [
+        "localStorage.getItem('web:auth_state')",
+        "sessionStorage.getItem('web:auth_state')",
+        "JSON.stringify(Object.fromEntries(Object.keys(localStorage).map(function(k){ return [k, localStorage.getItem(k)]; })))",
+        "JSON.stringify(Object.fromEntries(Object.keys(sessionStorage).map(function(k){ return [k, sessionStorage.getItem(k)]; })))",
+        "document.cookie",
+    ]
+
+    for app_name in BROWSER_APPS:
+        try:
+            origin = get_active_browser_origin(app_name)
+        except Exception as exc:
+            errors.append("{}: {}".format(app_name, exc))
+            continue
+
+        if "robinhood.com" not in origin:
+            errors.append("{}: active tab is {}".format(app_name, origin or "not readable"))
+            continue
+
+        for script in scripts:
+            try:
+                value = read_active_browser_script(app_name, script)
+            except Exception as exc:
+                errors.append("{}: {}".format(app_name, exc))
+                break
+
+            if not value:
+                continue
+
+            if script in ("localStorage.getItem('web:auth_state')", "sessionStorage.getItem('web:auth_state')"):
+                try:
+                    payload = json.loads(value)
+                    token = (payload.get("access_token") or "").strip()
+                    if token:
+                        return token, app_name
+                except Exception:
+                    pass
+
+            if script == "document.cookie":
+                for part in value.split(";"):
+                    name, _, cookie_value = part.strip().partition("=")
+                    if "Access-Token" in name and cookie_value:
+                        return cookie_value.strip(), app_name
+
+            if script.startswith("JSON.stringify("):
+                try:
+                    payload = json.loads(value)
+                except Exception:
+                    continue
+                for key, candidate in payload.items():
+                    if not isinstance(candidate, str):
+                        continue
+                    if key == "web:auth_state":
+                        try:
+                            auth_state = json.loads(candidate)
+                            token = (auth_state.get("access_token") or "").strip()
+                            if token:
+                                return token, app_name
+                        except Exception:
+                            pass
+                    if "token" in key.lower() and candidate.count(".") >= 2:
+                        return candidate.strip(), app_name
+
+        errors.append("{}: Robinhood tab found, but no access token was discovered".format(app_name))
+
+    raise RuntimeError("Unable to read a Robinhood browser tab access token. {}".format(" | ".join(errors)))

--- a/cmux_auth.py
+++ b/cmux_auth.py
@@ -4,22 +4,32 @@ import json
 import os
 import re
 import subprocess
+import time
 
 
 AUTH_STATE_KEY = "web:auth_state"
 
 
 def run_cmux(args):
-    result = subprocess.run(
-        ["cmux"] + args,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
-    if result.returncode != 0:
+    attempts = 4
+    last_message = "cmux command failed"
+    for attempt in range(attempts):
+        result = subprocess.run(
+            ["cmux"] + args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+
         message = result.stderr.strip() or result.stdout.strip() or "cmux command failed"
-        raise RuntimeError(message)
-    return result.stdout.strip()
+        last_message = message
+        if "Failed to connect to socket" not in message or attempt == attempts - 1:
+            raise RuntimeError(message)
+        time.sleep(0.25 * (attempt + 1))
+
+    raise RuntimeError(last_message)
 
 
 def _normalize_eval_output(value):

--- a/cmux_auth.py
+++ b/cmux_auth.py
@@ -1,0 +1,112 @@
+from __future__ import print_function
+
+import json
+import os
+import re
+import subprocess
+
+
+AUTH_STATE_KEY = "web:auth_state"
+
+
+def run_cmux(args):
+    result = subprocess.run(
+        ["cmux"] + args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip() or "cmux command failed"
+        raise RuntimeError(message)
+    return result.stdout.strip()
+
+
+def _normalize_eval_output(value):
+    value = value.strip()
+    if value in ("", "null", "undefined"):
+        return ""
+    if value.startswith('"') and value.endswith('"'):
+        try:
+            return json.loads(value)
+        except ValueError:
+            return value[1:-1]
+    return value
+
+
+def get_cmux_access_token(surface):
+    auth_state_raw = run_cmux(
+        ["browser", "eval", "--surface", surface, "localStorage.getItem('{}')".format(AUTH_STATE_KEY)]
+    )
+    auth_state_raw = _normalize_eval_output(auth_state_raw)
+    if auth_state_raw:
+        auth_state = json.loads(auth_state_raw)
+        token = auth_state.get("access_token", "").strip()
+        if token:
+            return token
+
+    cookies = run_cmux(["browser", "eval", "--surface", surface, "document.cookie"])
+    match = re.search(r"__Host-Web-App-Secondary-Access-Token=([^;]+)", cookies)
+    if match:
+        return match.group(1).strip()
+
+    raise RuntimeError("No Robinhood access token found on cmux surface {}.".format(surface))
+
+
+def clear_cmux_auth(surface):
+    script = r"""
+(() => {
+  const expire = (name, domain) => {
+    let cookie = `${name}=; Max-Age=0; path=/`;
+    if (location.protocol === 'https:') cookie += '; Secure';
+    if (domain) cookie += `; domain=${domain}`;
+    document.cookie = cookie;
+  };
+
+  try {
+    localStorage.removeItem('web:auth_state');
+    localStorage.removeItem('web:auth_last_accessed_time');
+  } catch (err) {}
+
+  try {
+    sessionStorage.clear();
+  } catch (err) {}
+
+  const names = document.cookie
+    .split(';')
+    .map(part => part.split('=')[0].trim())
+    .filter(Boolean);
+  names.forEach(name => {
+    expire(name, null);
+    expire(name, location.hostname);
+    expire(name, '.robinhood.com');
+  });
+
+  return true;
+})()
+""".strip()
+    run_cmux(["browser", "eval", "--surface", surface, script])
+
+
+def clear_env_access_token(env_path):
+    if not env_path or not os.path.exists(env_path):
+        return False
+
+    with open(env_path, "r") as infile:
+        lines = infile.readlines()
+
+    updated_lines = []
+    changed = False
+    for line in lines:
+        if line.startswith("RH_ACCESS_TOKEN="):
+            updated_lines.append("RH_ACCESS_TOKEN=\n")
+            changed = True
+        else:
+            updated_lines.append(line)
+
+    if not changed:
+        return False
+
+    with open(env_path, "w") as outfile:
+        outfile.writelines(updated_lines)
+    return True

--- a/csv-export.py
+++ b/csv-export.py
@@ -6,6 +6,7 @@ from dotenv import find_dotenv, load_dotenv
 from Robinhood import Robinhood
 from exporters import export_dividends
 from exporters import export_stock_history
+from profit_extractor import export_wash_sale_candidates
 from login_data import collect_login_data
 from profit_extractor import profit_extractor
 
@@ -29,6 +30,10 @@ parser.add_argument(
     '--profit', action='store_true', help='calculate profit for each sale')
 parser.add_argument(
     '--dividends', action='store_true', help='export dividend payments')
+parser.add_argument(
+    '--include-non-filled', action='store_true', help='include non-filled orders in the stock history export')
+parser.add_argument(
+    '--wash-sales', action='store_true', help='generate a wash-sale screening CSV from the stock history export')
 args = parser.parse_args()
 username = args.username
 password = args.password
@@ -50,7 +55,11 @@ logged_in = collect_login_data(
     access_token=access_token,
 )
 
-filename, _ = export_stock_history(robinhood=robinhood, debug=args.debug)
+filename, _ = export_stock_history(
+    robinhood=robinhood,
+    debug=args.debug,
+    include_non_filled=args.include_non_filled,
+)
 
 
 if args.dividends:
@@ -58,3 +67,6 @@ if args.dividends:
 
 if args.profit and filename:
     profit_csv = profit_extractor("", filename)
+
+if args.wash_sales and filename:
+    export_wash_sale_candidates(filename)

--- a/csv-export.py
+++ b/csv-export.py
@@ -1,20 +1,20 @@
 from __future__ import print_function
+import argparse
+
+from dotenv import find_dotenv, load_dotenv
+
 from Robinhood import Robinhood
+from exporters import export_dividends
+from exporters import export_stock_history
 from login_data import collect_login_data
 from profit_extractor import profit_extractor
-import getpass
-import collections
-import argparse
-import ast
-from dotenv import load_dotenv, find_dotenv
-import os
 
 logged_in = False
 
 parser = argparse.ArgumentParser(
     description='Export Robinhood trades to a CSV file')
 parser.add_argument(
-    '--debug', action='store_true', help='store raw JSON output to debug.json')
+    '--debug', action='store_true', help='store raw JSON output to debug.txt')
 parser.add_argument(
     '--username', default='', help='your Robinhood username')
 parser.add_argument(
@@ -40,199 +40,11 @@ robinhood = Robinhood()
 # login to Robinhood
 logged_in = collect_login_data(robinhood_obj=robinhood, username=username, password=password, device_token=device_token, mfa_code=mfa_code)
 
-print("Pulling trades. Please wait...")
-
-fields = collections.defaultdict(dict)
-trade_count = 0
-queued_count = 0
-
-#holds instrument['symbols'] to reduce API ovehead {instrument_url:symbol}
-cached_instruments = {}
-
-# fetch order history and related metadata from the Robinhood API
-orders = robinhood.get_endpoint('orders')
-
-# load a debug file
-# raw_json = open('debug.txt','rU').read()
-# orders = ast.literal_eval(raw_json)
-
-# store debug
-if args.debug:
-    # save the CSV
-    try:
-        with open("debug.txt", "w+") as outfile:
-            outfile.write(str(orders))
-            print("Debug infomation written to debug.txt")
-    except IOError:
-        print('Oops.  Unable to write file to debug.txt')
-
-# do/while for pagination
-paginated = True
-page = 0
-while paginated:
-    for i, order in enumerate(orders['results']):
-        executions = order['executions']
-
-        symbol = cached_instruments.get(order['instrument'], False)
-        if not symbol:
-            symbol = robinhood.get_custom_endpoint(order['instrument'])['symbol']
-            cached_instruments[order['instrument']] = symbol
-
-        fields[i + (page * 100)]['symbol'] = symbol
-
-        for key, value in enumerate(order):
-            if value != "executions":
-                fields[i + (page * 100)][value] = order[value]
-
-        fields[i + (page * 100)]['num_of_executions'] = len(executions)
-        fields[i + (page * 100)]['execution_state'] = order['state']
-
-        if len(executions) > 0:
-            trade_count += 1
-            fields[i + (page * 100)]['execution_state'] = ("completed", "partially filled")[order['cumulative_quantity'] < order['quantity']]
-            fields[i + (page * 100)]['first_execution_at'] = executions[0]['timestamp']
-            fields[i + (page * 100)]['settlement_date'] = executions[0]['settlement_date']
-        elif order['state'] == "queued":
-            queued_count += 1
-    # paginate
-    if orders['next'] is not None:
-        page = page + 1
-        orders = robinhood.get_custom_endpoint(str(orders['next']))
-    else:
-        paginated = False
-
-# for i in fields:
-#   print fields[i]
-#   print "-------"
-
-# check we have trade data to export
-if trade_count > 0 or queued_count > 0:
-    print("%d queued trade%s and %d executed trade%s found in your account." %
-          (queued_count, "s" [queued_count == 1:], trade_count,
-           "s" [trade_count == 1:]))
-    # print str(queued_count) + " queded trade(s) and " + str(trade_count) + " executed trade(s) found in your account."
-else:
-    print("No trade history found in your account.")
-    quit()
-
-# CSV headers
-keys = fields[0].keys()
-keys = sorted(keys)
-csv = ','.join(keys) + "\n"
-
-# CSV rows
-for row in fields:
-    for idx, key in enumerate(keys):
-        if (idx > 0):
-            csv += ","
-        try:
-            csv += str(fields[row][key])
-        except:
-            csv += ""
-
-    csv += "\n"
-
-# choose a filename to save to
-print("Choose a filename or press enter to save to `robinhood.csv`:")
-try:
-    input = raw_input
-except NameError:
-    pass
-filename = input().strip()
-if filename == '':
-    filename = "robinhood.csv"
-
-try:
-    with open(filename, "w+") as outfile:
-        outfile.write(csv)
-except IOError:
-    print("Oops.  Unable to write file to ", filename)
+filename, _ = export_stock_history(robinhood=robinhood, debug=args.debug)
 
 
 if args.dividends:
-    fields=collections.defaultdict(dict)
-    dividend_count = 0
-    queued_dividends = 0
+    export_dividends(robinhood=robinhood, debug=args.debug)
 
-    # fetch order history and related metadata from the Robinhood API
-    dividends = robinhood.get_endpoint('dividends')
-
-
-    paginated = True
-    page = 0
-    while paginated:
-        for i, dividend in enumerate(dividends['results']):
-            symbol = cached_instruments.get(dividend['instrument'], False)
-            if not symbol:
-                symbol = robinhood.get_custom_endpoint(dividend['instrument'])['symbol']
-                cached_instruments[dividend['instrument']] = symbol
-
-            fields[i + (page * 100)]['symbol'] = symbol
-
-            for key, value in enumerate(dividend):
-                if value != "executions":
-                    fields[i + (page * 100)][value] = dividend[value]
-
-            fields[i + (page * 100)]['execution_state'] = order['state']
-
-            if dividend['state'] == "pending":
-                queued_dividends += 1
-            elif dividend['state'] == "paid":
-                dividend_count += 1
-        # paginate
-        if dividends['next'] is not None:
-            page = page + 1
-            orders = robinhood.get_custom_endpoint(str(dividends['next']))
-        else:
-            paginated = False
-
-    # for i in fields:
-    #   print fields[i]
-    #   print "-------"
-
-    # check we have trade data to export
-    if dividend_count > 0 or queued_dividends > 0:
-        print("%d queued dividend%s and %d executed dividend%s found in your account." %
-              (queued_dividends, "s" [queued_count == 1:], dividend_count,
-               "s" [trade_count == 1:]))
-        # print str(queued_count) + " queded trade(s) and " + str(trade_count) + " executed trade(s) found in your account."
-    else:
-        print("No dividend history found in your account.")
-        quit()
-
-    # CSV headers
-    keys = fields[0].keys()
-    keys = sorted(keys)
-    csv = ','.join(keys) + "\n"
-
-    # CSV rows
-    for row in fields:
-        for idx, key in enumerate(keys):
-            if (idx > 0):
-                csv += ","
-            try:
-                csv += str(fields[row][key])
-            except:
-                csv += ""
-
-        csv += "\n"
-
-    # choose a filename to save to
-    print("Choose a filename or press enter to save to `dividends.csv`:")
-    try:
-        input = raw_input
-    except NameError:
-        pass
-    filename = input().strip()
-    if filename == '':
-        filename = "dividends.csv"
-
-    # save the CSV
-    try:
-        with open(filename, "w+") as outfile:
-            outfile.write(csv)
-    except IOError:
-        print("Oops.  Unable to write file to ", filename)
-
-if args.profit:
-    profit_csv = profit_extractor(csv, filename)
+if args.profit and filename:
+    profit_csv = profit_extractor("", filename)

--- a/csv-export.py
+++ b/csv-export.py
@@ -24,6 +24,8 @@ parser.add_argument(
 parser.add_argument(
     '--device_token', help='your device token')
 parser.add_argument(
+    '--access-token', default='', help='your Robinhood bearer token')
+parser.add_argument(
     '--profit', action='store_true', help='calculate profit for each sale')
 parser.add_argument(
     '--dividends', action='store_true', help='export dividend payments')
@@ -32,13 +34,21 @@ username = args.username
 password = args.password
 mfa_code = args.mfa_code
 device_token = args.device_token
+access_token = args.access_token
 
 load_dotenv(find_dotenv())
 
 robinhood = Robinhood()
 
 # login to Robinhood
-logged_in = collect_login_data(robinhood_obj=robinhood, username=username, password=password, device_token=device_token, mfa_code=mfa_code)
+logged_in = collect_login_data(
+    robinhood_obj=robinhood,
+    username=username,
+    password=password,
+    device_token=device_token,
+    mfa_code=mfa_code,
+    access_token=access_token,
+)
 
 filename, _ = export_stock_history(robinhood=robinhood, debug=args.debug)
 

--- a/csv-holdings-export.py
+++ b/csv-holdings-export.py
@@ -1,0 +1,166 @@
+from __future__ import print_function
+
+import argparse
+import collections
+from decimal import Decimal, InvalidOperation
+
+from dotenv import find_dotenv, load_dotenv
+
+from Robinhood import Robinhood
+from login_data import collect_login_data
+
+
+def as_decimal(value):
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def is_open_stock_position(position):
+    return as_decimal(position.get("quantity")) > 0
+
+
+def fetch_paginated_results(robinhood, endpoint_name):
+    response = robinhood.get_endpoint(endpoint_name)
+    results = []
+
+    while True:
+        results.extend(response.get("results", []))
+        next_url = response.get("next")
+        if not next_url:
+            break
+        response = robinhood.get_custom_endpoint(str(next_url))
+
+    return results
+
+
+def build_holdings_rows(robinhood, positions, include_closed):
+    rows = collections.defaultdict(dict)
+    cached_instruments = {}
+    row = 0
+
+    for position in positions:
+        if not include_closed and not is_open_stock_position(position):
+            continue
+
+        instrument_url = position.get("instrument")
+        symbol = ""
+        if instrument_url:
+            instrument = cached_instruments.get(instrument_url)
+            if not instrument:
+                instrument = robinhood.get_custom_endpoint(instrument_url)
+                cached_instruments[instrument_url] = instrument
+            symbol = instrument.get("symbol", "")
+
+        rows[row]["symbol"] = symbol
+        rows[row]["is_open_position"] = is_open_stock_position(position)
+
+        # Keep all original API fields so the CSV remains useful even if Robinhood
+        # adds data we do not explicitly model here.
+        for key in position:
+            rows[row][key] = position[key]
+
+        row += 1
+
+    return rows
+
+
+def write_csv(fields, default_filename):
+    if not fields:
+        print("No holdings found.")
+        return
+
+    keys = sorted(fields[0].keys())
+    csv = ",".join(keys) + "\n"
+
+    for row in fields:
+        for idx, key in enumerate(keys):
+            if idx > 0:
+                csv += ","
+            try:
+                csv += str(fields[row][key])
+            except Exception:
+                csv += ""
+        csv += "\n"
+
+    print("Choose a filename or press enter to save to `{}`:".format(default_filename))
+    try:
+        input = raw_input
+    except NameError:
+        pass
+    filename = input().strip()
+    if filename == "":
+        filename = default_filename
+
+    try:
+        with open(filename, "w+") as outfile:
+            outfile.write(csv)
+        print("Wrote {} rows to {}.".format(len(fields), filename))
+    except IOError:
+        print("Oops. Unable to write file to {}.".format(filename))
+
+
+parser = argparse.ArgumentParser(
+    description="Export Robinhood stock holdings to a CSV file"
+)
+parser.add_argument("--debug", action="store_true", help="store raw JSON output to debug-holdings.txt")
+parser.add_argument("--username", default="", help="your Robinhood username")
+parser.add_argument("--password", default="", help="your Robinhood password")
+parser.add_argument("--mfa_code", help="your Robinhood mfa_code")
+parser.add_argument("--device_token", help="your device token")
+parser.add_argument(
+    "--include-closed",
+    action="store_true",
+    help="include zero-quantity positions returned by Robinhood, not just currently open holdings",
+)
+args = parser.parse_args()
+
+load_dotenv(find_dotenv())
+
+robinhood = Robinhood()
+collect_login_data(
+    robinhood_obj=robinhood,
+    username=args.username,
+    password=args.password,
+    device_token=args.device_token,
+    mfa_code=args.mfa_code,
+)
+
+print("Pulling stock holdings. Please wait...")
+
+positions = fetch_paginated_results(robinhood, "positions")
+
+if args.debug:
+    try:
+        with open("debug-holdings.txt", "w+") as outfile:
+            outfile.write(str(positions))
+        print("Debug information written to debug-holdings.txt")
+    except IOError:
+        print("Oops. Unable to write file to debug-holdings.txt")
+
+fields = build_holdings_rows(
+    robinhood=robinhood,
+    positions=positions,
+    include_closed=args.include_closed,
+)
+
+open_count = 0
+closed_count = 0
+for row in fields.values():
+    if row.get("is_open_position"):
+        open_count += 1
+    else:
+        closed_count += 1
+
+print(
+    "{} open stock holding{}{} found.".format(
+        open_count,
+        "s" [open_count == 1:],
+        "" if not args.include_closed else " and {} closed position{}.".format(
+            closed_count, "s" [closed_count == 1:]
+        ),
+    )
+)
+
+write_csv(fields, "stock-holdings.csv")

--- a/csv-holdings-export.py
+++ b/csv-holdings-export.py
@@ -17,6 +17,7 @@ parser.add_argument("--username", default="", help="your Robinhood username")
 parser.add_argument("--password", default="", help="your Robinhood password")
 parser.add_argument("--mfa_code", help="your Robinhood mfa_code")
 parser.add_argument("--device_token", help="your device token")
+parser.add_argument("--access-token", default="", help="your Robinhood bearer token")
 parser.add_argument(
     "--include-closed",
     action="store_true",
@@ -33,6 +34,7 @@ collect_login_data(
     password=args.password,
     device_token=args.device_token,
     mfa_code=args.mfa_code,
+    access_token=args.access_token,
 )
 
 export_stock_holdings(

--- a/csv-holdings-export.py
+++ b/csv-holdings-export.py
@@ -1,104 +1,12 @@
 from __future__ import print_function
 
 import argparse
-import collections
-from decimal import Decimal, InvalidOperation
 
 from dotenv import find_dotenv, load_dotenv
 
 from Robinhood import Robinhood
+from exporters import export_stock_holdings
 from login_data import collect_login_data
-
-
-def as_decimal(value):
-    try:
-        return Decimal(str(value))
-    except (InvalidOperation, TypeError, ValueError):
-        return Decimal("0")
-
-
-def is_open_stock_position(position):
-    return as_decimal(position.get("quantity")) > 0
-
-
-def fetch_paginated_results(robinhood, endpoint_name):
-    response = robinhood.get_endpoint(endpoint_name)
-    results = []
-
-    while True:
-        results.extend(response.get("results", []))
-        next_url = response.get("next")
-        if not next_url:
-            break
-        response = robinhood.get_custom_endpoint(str(next_url))
-
-    return results
-
-
-def build_holdings_rows(robinhood, positions, include_closed):
-    rows = collections.defaultdict(dict)
-    cached_instruments = {}
-    row = 0
-
-    for position in positions:
-        if not include_closed and not is_open_stock_position(position):
-            continue
-
-        instrument_url = position.get("instrument")
-        symbol = ""
-        if instrument_url:
-            instrument = cached_instruments.get(instrument_url)
-            if not instrument:
-                instrument = robinhood.get_custom_endpoint(instrument_url)
-                cached_instruments[instrument_url] = instrument
-            symbol = instrument.get("symbol", "")
-
-        rows[row]["symbol"] = symbol
-        rows[row]["is_open_position"] = is_open_stock_position(position)
-
-        # Keep all original API fields so the CSV remains useful even if Robinhood
-        # adds data we do not explicitly model here.
-        for key in position:
-            rows[row][key] = position[key]
-
-        row += 1
-
-    return rows
-
-
-def write_csv(fields, default_filename):
-    if not fields:
-        print("No holdings found.")
-        return
-
-    keys = sorted(fields[0].keys())
-    csv = ",".join(keys) + "\n"
-
-    for row in fields:
-        for idx, key in enumerate(keys):
-            if idx > 0:
-                csv += ","
-            try:
-                csv += str(fields[row][key])
-            except Exception:
-                csv += ""
-        csv += "\n"
-
-    print("Choose a filename or press enter to save to `{}`:".format(default_filename))
-    try:
-        input = raw_input
-    except NameError:
-        pass
-    filename = input().strip()
-    if filename == "":
-        filename = default_filename
-
-    try:
-        with open(filename, "w+") as outfile:
-            outfile.write(csv)
-        print("Wrote {} rows to {}.".format(len(fields), filename))
-    except IOError:
-        print("Oops. Unable to write file to {}.".format(filename))
 
 
 parser = argparse.ArgumentParser(
@@ -127,40 +35,8 @@ collect_login_data(
     mfa_code=args.mfa_code,
 )
 
-print("Pulling stock holdings. Please wait...")
-
-positions = fetch_paginated_results(robinhood, "positions")
-
-if args.debug:
-    try:
-        with open("debug-holdings.txt", "w+") as outfile:
-            outfile.write(str(positions))
-        print("Debug information written to debug-holdings.txt")
-    except IOError:
-        print("Oops. Unable to write file to debug-holdings.txt")
-
-fields = build_holdings_rows(
+export_stock_holdings(
     robinhood=robinhood,
-    positions=positions,
     include_closed=args.include_closed,
+    debug=args.debug,
 )
-
-open_count = 0
-closed_count = 0
-for row in fields.values():
-    if row.get("is_open_position"):
-        open_count += 1
-    else:
-        closed_count += 1
-
-print(
-    "{} open stock holding{}{} found.".format(
-        open_count,
-        "s" [open_count == 1:],
-        "" if not args.include_closed else " and {} closed position{}.".format(
-            closed_count, "s" [closed_count == 1:]
-        ),
-    )
-)
-
-write_csv(fields, "stock-holdings.csv")

--- a/csv-options-export.py
+++ b/csv-options-export.py
@@ -1,20 +1,19 @@
 from __future__ import print_function
+import argparse
+
+from dotenv import find_dotenv, load_dotenv
+
 from Robinhood import Robinhood
+from exporters import export_options_history
 from login_data import collect_login_data
 from profit_extractor import profit_extractor
-import getpass
-import collections
-import argparse
-import ast
-from dotenv import load_dotenv, find_dotenv
-import os
 
 logged_in = False
 
 parser = argparse.ArgumentParser(
-    description='Export Robinhood trades to a CSV file')
+    description='Export Robinhood options trades to a CSV file')
 parser.add_argument(
-    '--debug', action='store_true', help='store raw JSON output to debug.json')
+    '--debug', action='store_true', help='store raw JSON output to debug-options.txt')
 parser.add_argument(
     '--username', default='', help='your Robinhood username')
 parser.add_argument(
@@ -38,127 +37,7 @@ robinhood = Robinhood()
 # login to Robinhood
 logged_in = collect_login_data(robinhood_obj=robinhood, username=username, password=password, device_token=device_token, mfa_code=mfa_code)
 
-print("Pulling trades. Please wait...")
+filename, _ = export_options_history(robinhood=robinhood, debug=args.debug)
 
-fields = collections.defaultdict(dict)
-trade_count = 0
-queued_count = 0
-
-# fetch order history and related metadata from the Robinhood API
-#orders = robinhood.get_endpoint('orders')
-orders = robinhood.get_endpoint('optionsOrders');
-# load a debug file
-# raw_json = open('debug.txt','rU').read()
-# orders = ast.literal_eval(raw_json)
-
-# store debug
-if args.debug:
-    # save the CSV
-    try:
-        with open("debug.txt", "w+") as outfile:
-            outfile.write(str(orders))
-            print("Debug infomation written to debug.txt")
-    except IOError:
-        print('Oops.  Unable to write file to debug.txt')
-
-# Vignesh save the CSV
-try:
-    with open("stocks.txt", "w+") as outfile:
-        outfile.write(str(orders))
-except IOError:
-    print("Oops.  Unable to write options file to ", filename)
-#Vignesh end
-
-# do/while for pagination
-paginated = True
-page = 0
-row = 0
-while paginated:
-    for i, order in enumerate(orders['results']):
-        for j, leg in enumerate(order['legs']):
-            counter = row + (page * 100)
-            executions = leg['executions']
-            #Fetch meta info such as strike price, expiration, ticker name of this order
-            contract = robinhood.get_custom_endpoint(leg['option'])
-            fields[counter]['Leg'] = j + 1
-            fields[counter]['Ticker'] = contract['chain_symbol']
-            fields[counter]['Strike_price'] = contract['strike_price']
-            fields[counter]['Expiration_date'] = contract['expiration_date']
-            # Read thro all the data under the order and add it to the csv row
-            for key, value in enumerate(leg):
-                if value != 'executions':
-                        fields[counter][value] = leg[value]
-            for key, value in enumerate(order):
-                if value != "legs":
-                    fields[counter][value] = order[value]
-            # Update trade count if order was filled to report at the end about how many trades were exported
-            if order['state'] == "filled":
-                trade_count += 1
-                # Since the order is filled, read all the leg and execution information such as date placed, amount paid, drag them over to csv
-                for key, value in enumerate(executions[0]):
-                    fields[counter][value] = executions[0][value]
-            elif order['state'] == "queued":
-                queued_count += 1
-            #Add a calculation for the amount this trade will have effected on the buying power, this will help calculate total profit.
-            if leg['side'] == 'sell':
-                fields[counter]['Change_in_Buying_Power'] = order['processed_premium']
-            else:
-                fields[counter]['Change_in_Buying_Power'] = "-" + (order['processed_premium']);
-            row += 1
-    # paginate
-    if orders['next'] is not None:
-        page = page + 1
-        orders = robinhood.get_custom_endpoint(str(orders['next']))
-    else:
-        paginated = False
-
-# for i in fields:
-#   print fields[i]
-#   print "-------"
-
-# check we have trade data to export
-if trade_count > 0 or queued_count > 0:
-    print("%d queued trade%s and %d executed trade%s found in your account." %
-          (queued_count, "s" [queued_count == 1:], trade_count,
-           "s" [trade_count == 1:]))
-    # print str(queued_count) + " queded trade(s) and " + str(trade_count) + " executed trade(s) found in your account."
-else:
-    print("No trade history found in your account.")
-    quit()
-
-# CSV headers
-keys = fields[0].keys()
-#keys = sorted(keys)
-csv = ','.join(keys) + "\n"
-
-# CSV rows
-for row in fields:
-    for idx, key in enumerate(keys):
-        if (idx > 0):
-            csv += ","
-        try:
-            csv += str(fields[row][key])
-        except:
-            csv += ""
-
-    csv += "\n"
-
-# choose a filename to save to
-print("Choose a filename or press enter to save to `option-trades.csv`:")
-try:
-    input = raw_input
-except NameError:
-    pass
-filename = input().strip()
-if filename == '':
-    filename = "option-trades.csv"
-
-# save the CSV
-try:
-    with open(filename, "w+") as outfile:
-        outfile.write(csv)
-except IOError:
-    print("Oops. Unable to write file to ", filename, ". Close the file if it is open and try again.")
-
-if args.profit:
-    profit_csv = profit_extractor(csv, filename)
+if args.profit and filename:
+    profit_csv = profit_extractor("", filename)

--- a/csv-options-export.py
+++ b/csv-options-export.py
@@ -23,19 +23,29 @@ parser.add_argument(
 parser.add_argument(
     '--device_token', help='your device token')
 parser.add_argument(
+    '--access-token', default='', help='your Robinhood bearer token')
+parser.add_argument(
     '--profit', action='store_true', help='calculate profit for each sale')
 args = parser.parse_args()
 username = args.username
 password = args.password
 mfa_code = args.mfa_code
 device_token = args.device_token
+access_token = args.access_token
 
 load_dotenv(find_dotenv())
 
 robinhood = Robinhood()
 
 # login to Robinhood
-logged_in = collect_login_data(robinhood_obj=robinhood, username=username, password=password, device_token=device_token, mfa_code=mfa_code)
+logged_in = collect_login_data(
+    robinhood_obj=robinhood,
+    username=username,
+    password=password,
+    device_token=device_token,
+    mfa_code=mfa_code,
+    access_token=access_token,
+)
 
 filename, _ = export_options_history(robinhood=robinhood, debug=args.debug)
 

--- a/csv-options-holdings-export.py
+++ b/csv-options-holdings-export.py
@@ -1,109 +1,12 @@
 from __future__ import print_function
 
 import argparse
-import collections
-from decimal import Decimal, InvalidOperation
 
 from dotenv import find_dotenv, load_dotenv
 
 from Robinhood import Robinhood
+from exporters import export_options_holdings
 from login_data import collect_login_data
-
-
-def as_decimal(value):
-    try:
-        return Decimal(str(value))
-    except (InvalidOperation, TypeError, ValueError):
-        return Decimal("0")
-
-
-def is_open_option_position(position):
-    quantity = position.get("quantity")
-    if quantity is None:
-        quantity = position.get("tradable_quantity")
-    return as_decimal(quantity) > 0
-
-
-def fetch_paginated_results(robinhood, endpoint_name):
-    response = robinhood.get_endpoint(endpoint_name)
-    results = []
-
-    while True:
-        results.extend(response.get("results", []))
-        next_url = response.get("next")
-        if not next_url:
-            break
-        response = robinhood.get_custom_endpoint(str(next_url))
-
-    return results
-
-
-def build_holdings_rows(robinhood, positions, include_closed):
-    rows = collections.defaultdict(dict)
-    cached_contracts = {}
-    row = 0
-
-    for position in positions:
-        if not include_closed and not is_open_option_position(position):
-            continue
-
-        option_url = position.get("option")
-        contract = {}
-        if option_url:
-            contract = cached_contracts.get(option_url)
-            if not contract:
-                contract = robinhood.get_custom_endpoint(option_url)
-                cached_contracts[option_url] = contract
-
-        rows[row]["Ticker"] = contract.get("chain_symbol", "")
-        rows[row]["Strike_price"] = contract.get("strike_price", "")
-        rows[row]["Expiration_date"] = contract.get("expiration_date", "")
-        rows[row]["Type"] = contract.get("type", "")
-        rows[row]["is_open_position"] = is_open_option_position(position)
-
-        # Preserve the raw API payload so the export remains complete even if the
-        # response shape changes over time.
-        for key in position:
-            rows[row][key] = position[key]
-
-        row += 1
-
-    return rows
-
-
-def write_csv(fields, default_filename):
-    if not fields:
-        print("No holdings found.")
-        return
-
-    keys = sorted(fields[0].keys())
-    csv = ",".join(keys) + "\n"
-
-    for row in fields:
-        for idx, key in enumerate(keys):
-            if idx > 0:
-                csv += ","
-            try:
-                csv += str(fields[row][key])
-            except Exception:
-                csv += ""
-        csv += "\n"
-
-    print("Choose a filename or press enter to save to `{}`:".format(default_filename))
-    try:
-        input = raw_input
-    except NameError:
-        pass
-    filename = input().strip()
-    if filename == "":
-        filename = default_filename
-
-    try:
-        with open(filename, "w+") as outfile:
-            outfile.write(csv)
-        print("Wrote {} rows to {}.".format(len(fields), filename))
-    except IOError:
-        print("Oops. Unable to write file to {}.".format(filename))
 
 
 parser = argparse.ArgumentParser(
@@ -132,40 +35,8 @@ collect_login_data(
     mfa_code=args.mfa_code,
 )
 
-print("Pulling options holdings. Please wait...")
-
-positions = fetch_paginated_results(robinhood, "optionsPositions")
-
-if args.debug:
-    try:
-        with open("debug-options-holdings.txt", "w+") as outfile:
-            outfile.write(str(positions))
-        print("Debug information written to debug-options-holdings.txt")
-    except IOError:
-        print("Oops. Unable to write file to debug-options-holdings.txt")
-
-fields = build_holdings_rows(
+export_options_holdings(
     robinhood=robinhood,
-    positions=positions,
     include_closed=args.include_closed,
+    debug=args.debug,
 )
-
-open_count = 0
-closed_count = 0
-for row in fields.values():
-    if row.get("is_open_position"):
-        open_count += 1
-    else:
-        closed_count += 1
-
-print(
-    "{} open option holding{}{} found.".format(
-        open_count,
-        "s" [open_count == 1:],
-        "" if not args.include_closed else " and {} closed position{}.".format(
-            closed_count, "s" [closed_count == 1:]
-        ),
-    )
-)
-
-write_csv(fields, "option-holdings.csv")

--- a/csv-options-holdings-export.py
+++ b/csv-options-holdings-export.py
@@ -1,0 +1,171 @@
+from __future__ import print_function
+
+import argparse
+import collections
+from decimal import Decimal, InvalidOperation
+
+from dotenv import find_dotenv, load_dotenv
+
+from Robinhood import Robinhood
+from login_data import collect_login_data
+
+
+def as_decimal(value):
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def is_open_option_position(position):
+    quantity = position.get("quantity")
+    if quantity is None:
+        quantity = position.get("tradable_quantity")
+    return as_decimal(quantity) > 0
+
+
+def fetch_paginated_results(robinhood, endpoint_name):
+    response = robinhood.get_endpoint(endpoint_name)
+    results = []
+
+    while True:
+        results.extend(response.get("results", []))
+        next_url = response.get("next")
+        if not next_url:
+            break
+        response = robinhood.get_custom_endpoint(str(next_url))
+
+    return results
+
+
+def build_holdings_rows(robinhood, positions, include_closed):
+    rows = collections.defaultdict(dict)
+    cached_contracts = {}
+    row = 0
+
+    for position in positions:
+        if not include_closed and not is_open_option_position(position):
+            continue
+
+        option_url = position.get("option")
+        contract = {}
+        if option_url:
+            contract = cached_contracts.get(option_url)
+            if not contract:
+                contract = robinhood.get_custom_endpoint(option_url)
+                cached_contracts[option_url] = contract
+
+        rows[row]["Ticker"] = contract.get("chain_symbol", "")
+        rows[row]["Strike_price"] = contract.get("strike_price", "")
+        rows[row]["Expiration_date"] = contract.get("expiration_date", "")
+        rows[row]["Type"] = contract.get("type", "")
+        rows[row]["is_open_position"] = is_open_option_position(position)
+
+        # Preserve the raw API payload so the export remains complete even if the
+        # response shape changes over time.
+        for key in position:
+            rows[row][key] = position[key]
+
+        row += 1
+
+    return rows
+
+
+def write_csv(fields, default_filename):
+    if not fields:
+        print("No holdings found.")
+        return
+
+    keys = sorted(fields[0].keys())
+    csv = ",".join(keys) + "\n"
+
+    for row in fields:
+        for idx, key in enumerate(keys):
+            if idx > 0:
+                csv += ","
+            try:
+                csv += str(fields[row][key])
+            except Exception:
+                csv += ""
+        csv += "\n"
+
+    print("Choose a filename or press enter to save to `{}`:".format(default_filename))
+    try:
+        input = raw_input
+    except NameError:
+        pass
+    filename = input().strip()
+    if filename == "":
+        filename = default_filename
+
+    try:
+        with open(filename, "w+") as outfile:
+            outfile.write(csv)
+        print("Wrote {} rows to {}.".format(len(fields), filename))
+    except IOError:
+        print("Oops. Unable to write file to {}.".format(filename))
+
+
+parser = argparse.ArgumentParser(
+    description="Export Robinhood options holdings to a CSV file"
+)
+parser.add_argument("--debug", action="store_true", help="store raw JSON output to debug-options-holdings.txt")
+parser.add_argument("--username", default="", help="your Robinhood username")
+parser.add_argument("--password", default="", help="your Robinhood password")
+parser.add_argument("--mfa_code", help="your Robinhood mfa_code")
+parser.add_argument("--device_token", help="your device token")
+parser.add_argument(
+    "--include-closed",
+    action="store_true",
+    help="include zero-quantity option positions returned by Robinhood, not just currently open holdings",
+)
+args = parser.parse_args()
+
+load_dotenv(find_dotenv())
+
+robinhood = Robinhood()
+collect_login_data(
+    robinhood_obj=robinhood,
+    username=args.username,
+    password=args.password,
+    device_token=args.device_token,
+    mfa_code=args.mfa_code,
+)
+
+print("Pulling options holdings. Please wait...")
+
+positions = fetch_paginated_results(robinhood, "optionsPositions")
+
+if args.debug:
+    try:
+        with open("debug-options-holdings.txt", "w+") as outfile:
+            outfile.write(str(positions))
+        print("Debug information written to debug-options-holdings.txt")
+    except IOError:
+        print("Oops. Unable to write file to debug-options-holdings.txt")
+
+fields = build_holdings_rows(
+    robinhood=robinhood,
+    positions=positions,
+    include_closed=args.include_closed,
+)
+
+open_count = 0
+closed_count = 0
+for row in fields.values():
+    if row.get("is_open_position"):
+        open_count += 1
+    else:
+        closed_count += 1
+
+print(
+    "{} open option holding{}{} found.".format(
+        open_count,
+        "s" [open_count == 1:],
+        "" if not args.include_closed else " and {} closed position{}.".format(
+            closed_count, "s" [closed_count == 1:]
+        ),
+    )
+)
+
+write_csv(fields, "option-holdings.csv")

--- a/csv-options-holdings-export.py
+++ b/csv-options-holdings-export.py
@@ -17,6 +17,7 @@ parser.add_argument("--username", default="", help="your Robinhood username")
 parser.add_argument("--password", default="", help="your Robinhood password")
 parser.add_argument("--mfa_code", help="your Robinhood mfa_code")
 parser.add_argument("--device_token", help="your device token")
+parser.add_argument("--access-token", default="", help="your Robinhood bearer token")
 parser.add_argument(
     "--include-closed",
     action="store_true",
@@ -33,6 +34,7 @@ collect_login_data(
     password=args.password,
     device_token=args.device_token,
     mfa_code=args.mfa_code,
+    access_token=args.access_token,
 )
 
 export_options_holdings(

--- a/export-all.py
+++ b/export-all.py
@@ -12,6 +12,7 @@ from exporters import export_options_holdings
 from exporters import export_stock_history
 from exporters import export_stock_holdings
 from login_data import collect_login_data
+from profit_extractor import export_wash_sale_candidates
 from profit_extractor import profit_extractor
 
 
@@ -48,6 +49,16 @@ parser.add_argument(
     action="store_true",
     help="also generate profit CSVs for stock and options trade history",
 )
+parser.add_argument(
+    "--include-non-filled",
+    action="store_true",
+    help="include non-filled stock orders in the stock history export",
+)
+parser.add_argument(
+    "--wash-sales",
+    action="store_true",
+    help="also generate a wash-sale screening CSV for stock history",
+)
 args = parser.parse_args()
 
 load_dotenv(find_dotenv())
@@ -70,6 +81,7 @@ stock_history_filename, _ = export_stock_history(
     debug=args.debug,
     filename=output_path(args.output_dir, "robinhood.csv"),
     prompt=False,
+    include_non_filled=args.include_non_filled,
 )
 
 options_history_filename, _ = export_options_history(
@@ -108,6 +120,9 @@ if args.profit and stock_history_filename:
 
 if args.profit and options_history_filename:
     profit_extractor("", options_history_filename)
+
+if args.wash_sales and stock_history_filename:
+    export_wash_sale_candidates(stock_history_filename)
 
 print("Complete account export finished.")
 print("Trade history: {}".format(stock_history_filename or "not generated"))

--- a/export-all.py
+++ b/export-all.py
@@ -1,0 +1,114 @@
+from __future__ import print_function
+
+import argparse
+import os
+
+from dotenv import find_dotenv, load_dotenv
+
+from Robinhood import Robinhood
+from exporters import export_dividends
+from exporters import export_options_history
+from exporters import export_options_holdings
+from exporters import export_stock_history
+from exporters import export_stock_holdings
+from login_data import collect_login_data
+from profit_extractor import profit_extractor
+
+
+def output_path(output_dir, filename):
+    return os.path.join(output_dir, filename) if output_dir else filename
+
+
+parser = argparse.ArgumentParser(
+    description="Export a complete Robinhood account snapshot to CSV files"
+)
+parser.add_argument("--debug", action="store_true", help="store raw JSON output for each export")
+parser.add_argument("--username", default="", help="your Robinhood username")
+parser.add_argument("--password", default="", help="your Robinhood password")
+parser.add_argument("--mfa_code", help="your Robinhood mfa_code")
+parser.add_argument("--device_token", help="your device token")
+parser.add_argument(
+    "--include-closed",
+    action="store_true",
+    help="include zero-quantity positions in holdings exports",
+)
+parser.add_argument(
+    "--output-dir",
+    default="",
+    help="directory for generated CSV files; defaults to the current directory",
+)
+parser.add_argument(
+    "--dividends",
+    action="store_true",
+    help="also export dividends to dividends.csv",
+)
+parser.add_argument(
+    "--profit",
+    action="store_true",
+    help="also generate profit CSVs for stock and options trade history",
+)
+args = parser.parse_args()
+
+load_dotenv(find_dotenv())
+
+if args.output_dir and not os.path.isdir(args.output_dir):
+    os.makedirs(args.output_dir)
+
+robinhood = Robinhood()
+collect_login_data(
+    robinhood_obj=robinhood,
+    username=args.username,
+    password=args.password,
+    device_token=args.device_token,
+    mfa_code=args.mfa_code,
+)
+
+stock_history_filename, _ = export_stock_history(
+    robinhood=robinhood,
+    debug=args.debug,
+    filename=output_path(args.output_dir, "robinhood.csv"),
+    prompt=False,
+)
+
+options_history_filename, _ = export_options_history(
+    robinhood=robinhood,
+    debug=args.debug,
+    filename=output_path(args.output_dir, "option-trades.csv"),
+    prompt=False,
+)
+
+stock_holdings_filename, _ = export_stock_holdings(
+    robinhood=robinhood,
+    include_closed=args.include_closed,
+    debug=args.debug,
+    filename=output_path(args.output_dir, "stock-holdings.csv"),
+    prompt=False,
+)
+
+options_holdings_filename, _ = export_options_holdings(
+    robinhood=robinhood,
+    include_closed=args.include_closed,
+    debug=args.debug,
+    filename=output_path(args.output_dir, "option-holdings.csv"),
+    prompt=False,
+)
+
+if args.dividends:
+    export_dividends(
+        robinhood=robinhood,
+        debug=args.debug,
+        filename=output_path(args.output_dir, "dividends.csv"),
+        prompt=False,
+    )
+
+if args.profit and stock_history_filename:
+    profit_extractor("", stock_history_filename)
+
+if args.profit and options_history_filename:
+    profit_extractor("", options_history_filename)
+
+print("Complete account export finished.")
+print("Trade history: {}".format(stock_history_filename or "not generated"))
+print("Options history: {}".format(options_history_filename or "not generated"))
+print("Stock holdings: {}".format(stock_holdings_filename or "not generated"))
+print("Options holdings: {}".format(options_holdings_filename or "not generated"))

--- a/export-all.py
+++ b/export-all.py
@@ -27,6 +27,7 @@ parser.add_argument("--username", default="", help="your Robinhood username")
 parser.add_argument("--password", default="", help="your Robinhood password")
 parser.add_argument("--mfa_code", help="your Robinhood mfa_code")
 parser.add_argument("--device_token", help="your device token")
+parser.add_argument("--access-token", default="", help="your Robinhood bearer token")
 parser.add_argument(
     "--include-closed",
     action="store_true",
@@ -61,6 +62,7 @@ collect_login_data(
     password=args.password,
     device_token=args.device_token,
     mfa_code=args.mfa_code,
+    access_token=args.access_token,
 )
 
 stock_history_filename, _ = export_stock_history(

--- a/export-from-browser-cookies.py
+++ b/export-from-browser-cookies.py
@@ -6,9 +6,9 @@ import os
 from dotenv import find_dotenv, load_dotenv
 
 from Robinhood import Robinhood
-from cmux_auth import clear_cmux_auth
-from cmux_auth import clear_env_access_token
-from cmux_auth import get_cmux_access_token
+from browser_cookie_auth import available_browsers
+from browser_cookie_auth import clear_env_access_token
+from browser_cookie_auth import get_browser_access_token
 from exporters import export_dividends
 from exporters import export_options_history
 from exporters import export_options_holdings
@@ -24,9 +24,15 @@ def output_path(output_dir, filename):
 
 
 parser = argparse.ArgumentParser(
-    description="Export Robinhood data using a logged-in cmux browser surface"
+    description="Export Robinhood data using access tokens read from a local browser cookie store"
 )
-parser.add_argument("--cmux-surface", required=True, help="cmux browser surface, for example surface:13")
+parser.add_argument(
+    "--browser",
+    default="auto",
+    help="browser to read cookies from; default: auto. Choices: auto, {}".format(
+        ", ".join(available_browsers())
+    ),
+)
 parser.add_argument("--debug", action="store_true", help="store raw JSON output for each export")
 parser.add_argument(
     "--include-closed",
@@ -58,11 +64,6 @@ parser.add_argument(
     action="store_true",
     help="also generate a wash-sale screening CSV for stock history",
 )
-parser.add_argument(
-    "--keep-auth",
-    action="store_true",
-    help="keep the Robinhood auth state in the cmux browser instead of clearing it after export",
-)
 args = parser.parse_args()
 
 env_path = find_dotenv()
@@ -71,7 +72,8 @@ load_dotenv(env_path)
 if args.output_dir and not os.path.isdir(args.output_dir):
     os.makedirs(args.output_dir)
 
-token = get_cmux_access_token(args.cmux_surface)
+token, browser_name = get_browser_access_token(args.browser)
+print("Read Robinhood access token from {}.".format(browser_name))
 robinhood = Robinhood()
 
 cleanup_errors = []
@@ -135,26 +137,21 @@ try:
         export_wash_sale_candidates(stock_history_filename)
 
     print("Complete account export finished.")
+    print("Browser source: {}".format(browser_name))
     print("Trade history: {}".format(stock_history_filename or "not generated"))
     print("Options history: {}".format(options_history_filename or "not generated"))
     print("Stock holdings: {}".format(stock_holdings_filename or "not generated"))
     print("Options holdings: {}".format(options_holdings_filename or "not generated"))
 finally:
-    if not args.keep_auth:
-        try:
-            clear_cmux_auth(args.cmux_surface)
-            print("Cleared Robinhood auth state from {}.".format(args.cmux_surface))
-        except Exception as exc:
-            cleanup_errors.append("cmux browser cleanup failed: {}".format(exc))
+    try:
+        if clear_env_access_token(env_path):
+            print("Cleared RH_ACCESS_TOKEN in {}.".format(env_path))
+    except Exception as exc:
+        cleanup_errors.append("env cleanup failed: {}".format(exc))
 
-        try:
-            if clear_env_access_token(env_path):
-                print("Cleared RH_ACCESS_TOKEN in {}.".format(env_path))
-        except Exception as exc:
-            cleanup_errors.append("env cleanup failed: {}".format(exc))
+    if cleanup_errors:
+        print("Cleanup warnings:")
+        for message in cleanup_errors:
+            print("- {}".format(message))
 
-        if cleanup_errors:
-            print("Cleanup warnings:")
-            for message in cleanup_errors:
-                print("- {}".format(message))
-            print("This does not clear command history, tool logs, or previously approved command prefixes.")
+    print("Browser cookies were not modified. Log out of Robinhood in the browser when you are done.")

--- a/export-from-cmux.py
+++ b/export-from-cmux.py
@@ -1,0 +1,145 @@
+from __future__ import print_function
+
+import argparse
+import os
+
+from dotenv import find_dotenv, load_dotenv
+
+from Robinhood import Robinhood
+from cmux_auth import clear_cmux_auth
+from cmux_auth import clear_env_access_token
+from cmux_auth import get_cmux_access_token
+from exporters import export_dividends
+from exporters import export_options_history
+from exporters import export_options_holdings
+from exporters import export_stock_history
+from exporters import export_stock_holdings
+from login_data import collect_login_data
+from profit_extractor import profit_extractor
+
+
+def output_path(output_dir, filename):
+    return os.path.join(output_dir, filename) if output_dir else filename
+
+
+parser = argparse.ArgumentParser(
+    description="Export Robinhood data using a logged-in cmux browser surface"
+)
+parser.add_argument("--cmux-surface", required=True, help="cmux browser surface, for example surface:13")
+parser.add_argument("--debug", action="store_true", help="store raw JSON output for each export")
+parser.add_argument(
+    "--include-closed",
+    action="store_true",
+    help="include zero-quantity positions in holdings exports",
+)
+parser.add_argument(
+    "--output-dir",
+    default="",
+    help="directory for generated CSV files; defaults to the current directory",
+)
+parser.add_argument(
+    "--dividends",
+    action="store_true",
+    help="also export dividends to dividends.csv",
+)
+parser.add_argument(
+    "--profit",
+    action="store_true",
+    help="also generate profit CSVs for stock and options trade history",
+)
+parser.add_argument(
+    "--keep-auth",
+    action="store_true",
+    help="keep the Robinhood auth state in the cmux browser instead of clearing it after export",
+)
+args = parser.parse_args()
+
+env_path = find_dotenv()
+load_dotenv(env_path)
+
+if args.output_dir and not os.path.isdir(args.output_dir):
+    os.makedirs(args.output_dir)
+
+token = get_cmux_access_token(args.cmux_surface)
+robinhood = Robinhood()
+
+cleanup_errors = []
+
+try:
+    collect_login_data(
+        robinhood_obj=robinhood,
+        username="",
+        password="",
+        device_token=None,
+        mfa_code=None,
+        access_token=token,
+    )
+
+    stock_history_filename, _ = export_stock_history(
+        robinhood=robinhood,
+        debug=args.debug,
+        filename=output_path(args.output_dir, "robinhood.csv"),
+        prompt=False,
+    )
+
+    options_history_filename, _ = export_options_history(
+        robinhood=robinhood,
+        debug=args.debug,
+        filename=output_path(args.output_dir, "option-trades.csv"),
+        prompt=False,
+    )
+
+    stock_holdings_filename, _ = export_stock_holdings(
+        robinhood=robinhood,
+        include_closed=args.include_closed,
+        debug=args.debug,
+        filename=output_path(args.output_dir, "stock-holdings.csv"),
+        prompt=False,
+    )
+
+    options_holdings_filename, _ = export_options_holdings(
+        robinhood=robinhood,
+        include_closed=args.include_closed,
+        debug=args.debug,
+        filename=output_path(args.output_dir, "option-holdings.csv"),
+        prompt=False,
+    )
+
+    if args.dividends:
+        export_dividends(
+            robinhood=robinhood,
+            debug=args.debug,
+            filename=output_path(args.output_dir, "dividends.csv"),
+            prompt=False,
+        )
+
+    if args.profit and stock_history_filename:
+        profit_extractor("", stock_history_filename)
+
+    if args.profit and options_history_filename:
+        profit_extractor("", options_history_filename)
+
+    print("Complete account export finished.")
+    print("Trade history: {}".format(stock_history_filename or "not generated"))
+    print("Options history: {}".format(options_history_filename or "not generated"))
+    print("Stock holdings: {}".format(stock_holdings_filename or "not generated"))
+    print("Options holdings: {}".format(options_holdings_filename or "not generated"))
+finally:
+    if not args.keep_auth:
+        try:
+            clear_cmux_auth(args.cmux_surface)
+            print("Cleared Robinhood auth state from {}.".format(args.cmux_surface))
+        except Exception as exc:
+            cleanup_errors.append("cmux browser cleanup failed: {}".format(exc))
+
+        try:
+            if clear_env_access_token(env_path):
+                print("Cleared RH_ACCESS_TOKEN in {}.".format(env_path))
+        except Exception as exc:
+            cleanup_errors.append("env cleanup failed: {}".format(exc))
+
+        if cleanup_errors:
+            print("Cleanup warnings:")
+            for message in cleanup_errors:
+                print("- {}".format(message))
+            print("This does not clear command history, tool logs, or previously approved command prefixes.")

--- a/exporters.py
+++ b/exporters.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import collections
+import csv
 from decimal import Decimal, InvalidOperation
 
 
@@ -50,38 +51,59 @@ def prompt_for_filename(default_filename):
 
 
 def write_csv(fields, default_filename, filename=None, prompt=True):
-    if not fields:
+    if isinstance(fields, dict):
+        rows = [fields[key] for key in sorted(fields.keys())]
+    else:
+        rows = list(fields)
+
+    if not rows:
         print("No rows found to export.")
         return None
 
-    keys = sorted(fields[0].keys())
-    csv = ",".join(keys) + "\n"
-
-    for row in fields:
-        for idx, key in enumerate(keys):
-            if idx > 0:
-                csv += ","
-            try:
-                csv += str(fields[row][key])
-            except Exception:
-                csv += ""
-        csv += "\n"
+    keys = []
+    for row in rows:
+        for key in row.keys():
+            if key not in keys:
+                keys.append(key)
 
     if not filename:
         filename = prompt_for_filename(default_filename) if prompt else default_filename
 
     try:
         with open(filename, "w+") as outfile:
-            outfile.write(csv)
-        print("Wrote {} rows to {}.".format(len(fields), filename))
+            writer = csv.DictWriter(outfile, fieldnames=keys, extrasaction="ignore")
+            writer.writeheader()
+            writer.writerows(rows)
+        print("Wrote {} rows to {}.".format(len(rows), filename))
         return filename
     except IOError:
         print("Oops. Unable to write file to {}.".format(filename))
         return None
 
 
-def build_stock_history_rows(robinhood, orders):
-    fields = collections.defaultdict(dict)
+def money_amount(value):
+    if isinstance(value, dict):
+        return value.get("amount", "")
+    return value or ""
+
+
+def first_execution(executions):
+    if executions:
+        return executions[0]
+    return {}
+
+
+def derive_stock_execution_state(order):
+    executions = order.get("executions", [])
+    if executions:
+        if as_decimal(order.get("cumulative_quantity")) < as_decimal(order.get("quantity")):
+            return "partially filled"
+        return "completed"
+    return order.get("state", "")
+
+
+def build_stock_history_rows(robinhood, orders, include_non_filled=False):
+    fields = []
     trade_count = 0
     queued_count = 0
     cached_instruments = {}
@@ -90,31 +112,53 @@ def build_stock_history_rows(robinhood, orders):
     page = 0
     current_orders = orders
     while paginated:
-        for i, order in enumerate(current_orders["results"]):
-            executions = order["executions"]
+        for order in current_orders["results"]:
+            executions = order.get("executions", [])
+            execution = first_execution(executions)
+            if not include_non_filled and order.get("state") != "filled":
+                if order.get("state") == "queued":
+                    queued_count += 1
+                continue
 
             symbol = cached_instruments.get(order["instrument"], False)
             if not symbol:
                 symbol = robinhood.get_custom_endpoint(order["instrument"])["symbol"]
                 cached_instruments[order["instrument"]] = symbol
 
-            fields[i + (page * 100)]["symbol"] = symbol
-
-            for key, value in enumerate(order):
-                if value != "executions":
-                    fields[i + (page * 100)][value] = order[value]
-
-            fields[i + (page * 100)]["num_of_executions"] = len(executions)
-            fields[i + (page * 100)]["execution_state"] = order["state"]
+            fields.append(
+                {
+                    "order_id": order.get("id", ""),
+                    "symbol": symbol,
+                    "side": order.get("side", ""),
+                    "state": order.get("state", ""),
+                    "execution_state": derive_stock_execution_state(order),
+                    "created_at": order.get("created_at", ""),
+                    "last_transaction_at": order.get("last_transaction_at", ""),
+                    "first_execution_at": execution.get("timestamp", ""),
+                    "settlement_date": execution.get("settlement_date", ""),
+                    "quantity": order.get("quantity", ""),
+                    "filled_quantity": order.get("cumulative_quantity", ""),
+                    "average_price": order.get("average_price", ""),
+                    "limit_price": order.get("price", ""),
+                    "requested_notional_amount": money_amount(order.get("requested_notional_amount"))
+                    or money_amount(order.get("dollar_based_amount")),
+                    "executed_notional_amount": money_amount(order.get("executed_notional")),
+                    "fees": money_amount(order.get("fees")),
+                    "market_hours": order.get("market_hours", ""),
+                    "time_in_force": order.get("time_in_force", ""),
+                    "trigger": order.get("trigger", ""),
+                    "order_type": order.get("type", ""),
+                    "position_effect": order.get("position_effect", ""),
+                    "ref_id": order.get("ref_id", ""),
+                    "order_url": order.get("url", ""),
+                    "instrument_id": order.get("instrument_id", ""),
+                    "trade_date": (execution.get("timestamp") or order.get("last_transaction_at") or "")[:10],
+                }
+            )
 
             if len(executions) > 0:
                 trade_count += 1
-                fields[i + (page * 100)]["execution_state"] = ("completed", "partially filled")[
-                    order["cumulative_quantity"] < order["quantity"]
-                ]
-                fields[i + (page * 100)]["first_execution_at"] = executions[0]["timestamp"]
-                fields[i + (page * 100)]["settlement_date"] = executions[0]["settlement_date"]
-            elif order["state"] == "queued":
+            elif include_non_filled and order.get("state") == "queued":
                 queued_count += 1
 
         if current_orders["next"] is not None:
@@ -126,12 +170,14 @@ def build_stock_history_rows(robinhood, orders):
     return fields, trade_count, queued_count
 
 
-def export_stock_history(robinhood, debug=False, filename=None, prompt=True):
+def export_stock_history(robinhood, debug=False, filename=None, prompt=True, include_non_filled=False):
     print("Pulling trades. Please wait...")
     orders = robinhood.get_endpoint("orders")
     maybe_write_debug_file(debug, "debug.txt", orders)
 
-    fields, trade_count, queued_count = build_stock_history_rows(robinhood, orders)
+    fields, trade_count, queued_count = build_stock_history_rows(
+        robinhood, orders, include_non_filled=include_non_filled
+    )
     if trade_count > 0 or queued_count > 0:
         print(
             "%d queued trade%s and %d executed trade%s found in your account."
@@ -200,43 +246,60 @@ def export_dividends(robinhood, debug=False, filename=None, prompt=True):
 
 
 def build_options_history_rows(robinhood, orders):
-    fields = collections.defaultdict(dict)
+    fields = []
     trade_count = 0
     queued_count = 0
-    page = 0
-    row = 0
     current_orders = orders
 
     paginated = True
     while paginated:
-        for i, order in enumerate(current_orders["results"]):
+        for order in current_orders["results"]:
             for j, leg in enumerate(order["legs"]):
-                counter = row + (page * 100)
-                executions = leg["executions"]
+                executions = leg.get("executions", [])
+                execution = first_execution(executions)
                 contract = robinhood.get_custom_endpoint(leg["option"])
-                fields[counter]["Leg"] = j + 1
-                fields[counter]["Ticker"] = contract["chain_symbol"]
-                fields[counter]["Strike_price"] = contract["strike_price"]
-                fields[counter]["Expiration_date"] = contract["expiration_date"]
-                for key, value in enumerate(leg):
-                    if value != "executions":
-                        fields[counter][value] = leg[value]
-                for key, value in enumerate(order):
-                    if value != "legs":
-                        fields[counter][value] = order[value]
-                if order["state"] == "filled" and executions:
+                fields.append(
+                    {
+                        "order_id": order.get("id", ""),
+                        "leg": j + 1,
+                        "ticker": contract.get("chain_symbol", ""),
+                        "option_type": contract.get("type", ""),
+                        "expiration_date": contract.get("expiration_date", ""),
+                        "strike_price": contract.get("strike_price", ""),
+                        "side": leg.get("side", ""),
+                        "position_effect": leg.get("position_effect", ""),
+                        "state": order.get("state", ""),
+                        "created_at": order.get("created_at", ""),
+                        "trade_date": execution.get("trade_date", ""),
+                        "timestamp": execution.get("timestamp", ""),
+                        "settlement_date": execution.get("settlement_date", ""),
+                        "quantity": order.get("quantity", ""),
+                        "filled_quantity": order.get("processed_quantity", ""),
+                        "price_per_contract": order.get("price", ""),
+                        "average_net_premium_paid": order.get("average_net_premium_paid", ""),
+                        "premium": order.get("premium", ""),
+                        "net_amount": order.get("net_amount", ""),
+                        "change_in_buying_power": (
+                            order.get("processed_premium", "")
+                            if leg.get("side") == "sell"
+                            else "-" + order.get("processed_premium", "")
+                        ),
+                        "contract_fees": order.get("contract_fees", ""),
+                        "regulatory_fees": order.get("regulatory_fees", ""),
+                        "strategy": order.get("strategy", ""),
+                        "time_in_force": order.get("time_in_force", ""),
+                        "trigger": order.get("trigger", ""),
+                        "order_type": order.get("type", ""),
+                        "ref_id": order.get("ref_id", ""),
+                        "option_id": contract.get("id", ""),
+                        "option_url": leg.get("option", ""),
+                    }
+                )
+                if order.get("state") == "filled" and executions:
                     trade_count += 1
-                    for key, value in enumerate(executions[0]):
-                        fields[counter][value] = executions[0][value]
-                elif order["state"] == "queued":
+                elif order.get("state") == "queued":
                     queued_count += 1
-                if leg["side"] == "sell":
-                    fields[counter]["Change_in_Buying_Power"] = order["processed_premium"]
-                else:
-                    fields[counter]["Change_in_Buying_Power"] = "-" + order["processed_premium"]
-                row += 1
         if current_orders["next"] is not None:
-            page += 1
             current_orders = robinhood.get_custom_endpoint(str(current_orders["next"]))
         else:
             paginated = False

--- a/exporters.py
+++ b/exporters.py
@@ -1,0 +1,385 @@
+from __future__ import print_function
+
+import collections
+from decimal import Decimal, InvalidOperation
+
+
+def as_decimal(value):
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal("0")
+
+
+def fetch_paginated_results(robinhood, endpoint_name):
+    response = robinhood.get_endpoint(endpoint_name)
+    results = []
+
+    while True:
+        results.extend(response.get("results", []))
+        next_url = response.get("next")
+        if not next_url:
+            break
+        response = robinhood.get_custom_endpoint(str(next_url))
+
+    return results
+
+
+def maybe_write_debug_file(debug, filename, payload):
+    if not debug:
+        return
+
+    try:
+        with open(filename, "w+") as outfile:
+            outfile.write(str(payload))
+        print("Debug information written to {}".format(filename))
+    except IOError:
+        print("Oops. Unable to write file to {}".format(filename))
+
+
+def prompt_for_filename(default_filename):
+    print("Choose a filename or press enter to save to `{}`:".format(default_filename))
+    try:
+        input = raw_input
+    except NameError:
+        pass
+    filename = input().strip()
+    if filename == "":
+        filename = default_filename
+    return filename
+
+
+def write_csv(fields, default_filename, filename=None, prompt=True):
+    if not fields:
+        print("No rows found to export.")
+        return None
+
+    keys = sorted(fields[0].keys())
+    csv = ",".join(keys) + "\n"
+
+    for row in fields:
+        for idx, key in enumerate(keys):
+            if idx > 0:
+                csv += ","
+            try:
+                csv += str(fields[row][key])
+            except Exception:
+                csv += ""
+        csv += "\n"
+
+    if not filename:
+        filename = prompt_for_filename(default_filename) if prompt else default_filename
+
+    try:
+        with open(filename, "w+") as outfile:
+            outfile.write(csv)
+        print("Wrote {} rows to {}.".format(len(fields), filename))
+        return filename
+    except IOError:
+        print("Oops. Unable to write file to {}.".format(filename))
+        return None
+
+
+def build_stock_history_rows(robinhood, orders):
+    fields = collections.defaultdict(dict)
+    trade_count = 0
+    queued_count = 0
+    cached_instruments = {}
+
+    paginated = True
+    page = 0
+    current_orders = orders
+    while paginated:
+        for i, order in enumerate(current_orders["results"]):
+            executions = order["executions"]
+
+            symbol = cached_instruments.get(order["instrument"], False)
+            if not symbol:
+                symbol = robinhood.get_custom_endpoint(order["instrument"])["symbol"]
+                cached_instruments[order["instrument"]] = symbol
+
+            fields[i + (page * 100)]["symbol"] = symbol
+
+            for key, value in enumerate(order):
+                if value != "executions":
+                    fields[i + (page * 100)][value] = order[value]
+
+            fields[i + (page * 100)]["num_of_executions"] = len(executions)
+            fields[i + (page * 100)]["execution_state"] = order["state"]
+
+            if len(executions) > 0:
+                trade_count += 1
+                fields[i + (page * 100)]["execution_state"] = ("completed", "partially filled")[
+                    order["cumulative_quantity"] < order["quantity"]
+                ]
+                fields[i + (page * 100)]["first_execution_at"] = executions[0]["timestamp"]
+                fields[i + (page * 100)]["settlement_date"] = executions[0]["settlement_date"]
+            elif order["state"] == "queued":
+                queued_count += 1
+
+        if current_orders["next"] is not None:
+            page += 1
+            current_orders = robinhood.get_custom_endpoint(str(current_orders["next"]))
+        else:
+            paginated = False
+
+    return fields, trade_count, queued_count
+
+
+def export_stock_history(robinhood, debug=False, filename=None, prompt=True):
+    print("Pulling trades. Please wait...")
+    orders = robinhood.get_endpoint("orders")
+    maybe_write_debug_file(debug, "debug.txt", orders)
+
+    fields, trade_count, queued_count = build_stock_history_rows(robinhood, orders)
+    if trade_count > 0 or queued_count > 0:
+        print(
+            "%d queued trade%s and %d executed trade%s found in your account."
+            % (queued_count, "s"[queued_count == 1 :], trade_count, "s"[trade_count == 1 :])
+        )
+    else:
+        print("No trade history found in your account.")
+        return None, fields
+
+    return write_csv(fields, "robinhood.csv", filename=filename, prompt=prompt), fields
+
+
+def export_dividends(robinhood, debug=False, filename=None, prompt=True):
+    cached_instruments = {}
+    fields = collections.defaultdict(dict)
+    dividend_count = 0
+    queued_dividends = 0
+
+    dividends = robinhood.get_endpoint("dividends")
+    maybe_write_debug_file(debug, "debug-dividends.txt", dividends)
+
+    paginated = True
+    page = 0
+    current_dividends = dividends
+    while paginated:
+        for i, dividend in enumerate(current_dividends["results"]):
+            symbol = cached_instruments.get(dividend["instrument"], False)
+            if not symbol:
+                symbol = robinhood.get_custom_endpoint(dividend["instrument"])["symbol"]
+                cached_instruments[dividend["instrument"]] = symbol
+
+            fields[i + (page * 100)]["symbol"] = symbol
+
+            for key, value in enumerate(dividend):
+                if value != "executions":
+                    fields[i + (page * 100)][value] = dividend[value]
+
+            fields[i + (page * 100)]["execution_state"] = dividend["state"]
+
+            if dividend["state"] == "pending":
+                queued_dividends += 1
+            elif dividend["state"] == "paid":
+                dividend_count += 1
+
+        if current_dividends["next"] is not None:
+            page += 1
+            current_dividends = robinhood.get_custom_endpoint(str(current_dividends["next"]))
+        else:
+            paginated = False
+
+    if dividend_count > 0 or queued_dividends > 0:
+        print(
+            "%d queued dividend%s and %d executed dividend%s found in your account."
+            % (
+                queued_dividends,
+                "s"[queued_dividends == 1 :],
+                dividend_count,
+                "s"[dividend_count == 1 :],
+            )
+        )
+    else:
+        print("No dividend history found in your account.")
+        return None, fields
+
+    return write_csv(fields, "dividends.csv", filename=filename, prompt=prompt), fields
+
+
+def build_options_history_rows(robinhood, orders):
+    fields = collections.defaultdict(dict)
+    trade_count = 0
+    queued_count = 0
+    page = 0
+    row = 0
+    current_orders = orders
+
+    paginated = True
+    while paginated:
+        for i, order in enumerate(current_orders["results"]):
+            for j, leg in enumerate(order["legs"]):
+                counter = row + (page * 100)
+                executions = leg["executions"]
+                contract = robinhood.get_custom_endpoint(leg["option"])
+                fields[counter]["Leg"] = j + 1
+                fields[counter]["Ticker"] = contract["chain_symbol"]
+                fields[counter]["Strike_price"] = contract["strike_price"]
+                fields[counter]["Expiration_date"] = contract["expiration_date"]
+                for key, value in enumerate(leg):
+                    if value != "executions":
+                        fields[counter][value] = leg[value]
+                for key, value in enumerate(order):
+                    if value != "legs":
+                        fields[counter][value] = order[value]
+                if order["state"] == "filled" and executions:
+                    trade_count += 1
+                    for key, value in enumerate(executions[0]):
+                        fields[counter][value] = executions[0][value]
+                elif order["state"] == "queued":
+                    queued_count += 1
+                if leg["side"] == "sell":
+                    fields[counter]["Change_in_Buying_Power"] = order["processed_premium"]
+                else:
+                    fields[counter]["Change_in_Buying_Power"] = "-" + order["processed_premium"]
+                row += 1
+        if current_orders["next"] is not None:
+            page += 1
+            current_orders = robinhood.get_custom_endpoint(str(current_orders["next"]))
+        else:
+            paginated = False
+
+    return fields, trade_count, queued_count
+
+
+def export_options_history(robinhood, debug=False, filename=None, prompt=True):
+    print("Pulling trades. Please wait...")
+    orders = robinhood.get_endpoint("optionsOrders")
+    maybe_write_debug_file(debug, "debug-options.txt", orders)
+
+    fields, trade_count, queued_count = build_options_history_rows(robinhood, orders)
+    if trade_count > 0 or queued_count > 0:
+        print(
+            "%d queued trade%s and %d executed trade%s found in your account."
+            % (queued_count, "s"[queued_count == 1 :], trade_count, "s"[trade_count == 1 :])
+        )
+    else:
+        print("No trade history found in your account.")
+        return None, fields
+
+    return write_csv(fields, "option-trades.csv", filename=filename, prompt=prompt), fields
+
+
+def is_open_stock_position(position):
+    return as_decimal(position.get("quantity")) > 0
+
+
+def build_stock_holdings_rows(robinhood, positions, include_closed):
+    rows = collections.defaultdict(dict)
+    cached_instruments = {}
+    row = 0
+
+    for position in positions:
+        if not include_closed and not is_open_stock_position(position):
+            continue
+
+        instrument_url = position.get("instrument")
+        symbol = ""
+        if instrument_url:
+            instrument = cached_instruments.get(instrument_url)
+            if not instrument:
+                instrument = robinhood.get_custom_endpoint(instrument_url)
+                cached_instruments[instrument_url] = instrument
+            symbol = instrument.get("symbol", "")
+
+        rows[row]["symbol"] = symbol
+        rows[row]["is_open_position"] = is_open_stock_position(position)
+
+        for key in position:
+            rows[row][key] = position[key]
+
+        row += 1
+
+    return rows
+
+
+def export_stock_holdings(robinhood, include_closed=False, debug=False, filename=None, prompt=True):
+    print("Pulling stock holdings. Please wait...")
+    positions = fetch_paginated_results(robinhood, "positions")
+    maybe_write_debug_file(debug, "debug-holdings.txt", positions)
+
+    fields = build_stock_holdings_rows(robinhood, positions, include_closed)
+    open_count = 0
+    closed_count = 0
+    for row in fields.values():
+        if row.get("is_open_position"):
+            open_count += 1
+        else:
+            closed_count += 1
+
+    print(
+        "{} open stock holding{}{} found.".format(
+            open_count,
+            "s"[open_count == 1 :],
+            ""
+            if not include_closed
+            else " and {} closed position{}.".format(closed_count, "s"[closed_count == 1 :]),
+        )
+    )
+    return write_csv(fields, "stock-holdings.csv", filename=filename, prompt=prompt), fields
+
+
+def is_open_option_position(position):
+    quantity = position.get("quantity")
+    if quantity is None:
+        quantity = position.get("tradable_quantity")
+    return as_decimal(quantity) > 0
+
+
+def build_options_holdings_rows(robinhood, positions, include_closed):
+    rows = collections.defaultdict(dict)
+    cached_contracts = {}
+    row = 0
+
+    for position in positions:
+        if not include_closed and not is_open_option_position(position):
+            continue
+
+        option_url = position.get("option")
+        contract = {}
+        if option_url:
+            contract = cached_contracts.get(option_url)
+            if not contract:
+                contract = robinhood.get_custom_endpoint(option_url)
+                cached_contracts[option_url] = contract
+
+        rows[row]["Ticker"] = contract.get("chain_symbol", "")
+        rows[row]["Strike_price"] = contract.get("strike_price", "")
+        rows[row]["Expiration_date"] = contract.get("expiration_date", "")
+        rows[row]["Type"] = contract.get("type", "")
+        rows[row]["is_open_position"] = is_open_option_position(position)
+
+        for key in position:
+            rows[row][key] = position[key]
+
+        row += 1
+
+    return rows
+
+
+def export_options_holdings(robinhood, include_closed=False, debug=False, filename=None, prompt=True):
+    print("Pulling options holdings. Please wait...")
+    positions = fetch_paginated_results(robinhood, "optionsPositions")
+    maybe_write_debug_file(debug, "debug-options-holdings.txt", positions)
+
+    fields = build_options_holdings_rows(robinhood, positions, include_closed)
+    open_count = 0
+    closed_count = 0
+    for row in fields.values():
+        if row.get("is_open_position"):
+            open_count += 1
+        else:
+            closed_count += 1
+
+    print(
+        "{} open option holding{}{} found.".format(
+            open_count,
+            "s"[open_count == 1 :],
+            ""
+            if not include_closed
+            else " and {} closed position{}.".format(closed_count, "s"[closed_count == 1 :]),
+        )
+    )
+    return write_csv(fields, "option-holdings.csv", filename=filename, prompt=prompt), fields

--- a/login_data.py
+++ b/login_data.py
@@ -13,40 +13,84 @@ def get_input():
         return input()
 
 
-def collect_login_data(robinhood_obj, username, password, device_token, mfa_code):
+def login_error_message(response):
+    if not isinstance(response, dict):
+        return "Login failed."
+
+    if response.get("mfa_required"):
+        return "Robinhood requires MFA."
+
+    for key in ("detail", "error", "message"):
+        value = response.get(key)
+        if value:
+            return str(value)
+
+    non_field_errors = response.get("non_field_errors")
+    if non_field_errors:
+        if isinstance(non_field_errors, list):
+            return "; ".join(str(item) for item in non_field_errors)
+        return str(non_field_errors)
+
+    return "Login failed."
+
+
+def collect_login_data(robinhood_obj, username, password, device_token, mfa_code, access_token=None):
     logged_in = False
+    if access_token == "":
+        access_token = None
+
+    use_env_access_token = access_token is None
+    use_env_username = username == ""
+    use_env_password = password == ""
+    use_env_device_token = device_token is None
+    use_env_mfa = mfa_code is None
+
+    if access_token is None and use_env_access_token:
+        access_token = os.getenv("RH_ACCESS_TOKEN", "")
+        use_env_access_token = False
+    if access_token:
+        robinhood_obj.set_auth_token(access_token)
+        logged_in = robinhood_obj.validate_auth_token()
+        if logged_in == True:
+            return True
+        print("\n{} Falling back to username/password login.\n".format(login_error_message(logged_in)))
+        access_token = ""
+
     while logged_in != True:
-        if username == "":
+        if username == "" and use_env_username:
             username = os.getenv("RH_USERNAME", "")
+            use_env_username = False
         if username == "":
             print("Robinhood username:", end=' ')
             username = get_input()
 
-        if password == "":
+        if password == "" and use_env_password:
             password = os.getenv("RH_PASSWORD", "")
+            use_env_password = False
         if password == "":
             password = getpass.getpass()
 
-        if device_token == None:
+        if device_token == None and use_env_device_token:
             device_token = os.getenv("RH_DEVICE_TOKEN", "")
+            use_env_device_token = False
         if device_token == "":
             device_token = str(uuid.uuid4())
 
         logged_in = robinhood_obj.login(username=username, password=password, device_token=device_token)
 
         if logged_in != True and logged_in.get('non_field_errors') == None and logged_in.get('mfa_required') == True:
-            if mfa_code is None:
+            if mfa_code is None and use_env_mfa:
                 mfa_code = os.getenv("RH_MFA")
-            if mfa_code == None:
+                use_env_mfa = False
+            if mfa_code == None or mfa_code == "":
                 print("Robinhood MFA:", end=' ')
                 mfa_code = get_input()
             logged_in = robinhood_obj.login(username=username, password=password, device_token=device_token, mfa_code=mfa_code)
 
         if logged_in != True:
-            print("\nInvalid inputs. Please try again.\n")
+            print("\n{} Please try again.\n".format(login_error_message(logged_in)))
             username = ""
             password = ""
-            device_token = ""
-            mfa_code = ""
+            mfa_code = None
 
     return True

--- a/login_data.py
+++ b/login_data.py
@@ -29,10 +29,8 @@ def collect_login_data(robinhood_obj, username, password, device_token, mfa_code
 
         if device_token == None:
             device_token = os.getenv("RH_DEVICE_TOKEN", "")
-            print("device token: ", device_token)
         if device_token == "":
-            device_token = uuid.uuid1()
-            print("Generated device token:", device_token)
+            device_token = str(uuid.uuid4())
 
         logged_in = robinhood_obj.login(username=username, password=password, device_token=device_token)
 

--- a/profit_extractor.py
+++ b/profit_extractor.py
@@ -1,123 +1,414 @@
 from datetime import timedelta
+import os
 
 import pandas as pd
 
 
-def profit_extractor(csv_val,  filename):
-    # choose a filename to save to
+EPSILON = 1e-9
+
+
+def first_present_column(frame, candidates):
+    for candidate in candidates:
+        if candidate in frame.columns:
+            return candidate
+    raise KeyError("Missing expected columns: {}".format(", ".join(candidates)))
+
+
+def sort_trade_frame(frame):
+    ordered = frame.copy().reset_index(drop=True)
+    ordered["row_sequence"] = ordered.index
+    return ordered.sort_values(["trade_timestamp", "row_sequence"]).reset_index(drop=True)
+
+
+def load_trade_frame(filename):
+    handle = pd.read_csv(filename)
+    date_col = first_present_column(handle, ["last_transaction_at", "first_execution_at", "created_at"])
+    quantity_col = first_present_column(handle, ["cumulative_quantity", "filled_quantity", "quantity"])
+    price_col = first_present_column(handle, ["average_price"])
+    symbol_col = first_present_column(handle, ["symbol"])
+    state_col = first_present_column(handle, ["state"])
+    side_col = first_present_column(handle, ["side"])
+    fees_col = first_present_column(handle, ["fees"])
+
+    handle["trade_timestamp"] = pd.to_datetime(handle[date_col], format="mixed", utc=True, errors="coerce")
+    handle = handle.dropna(subset=["trade_timestamp"])
+    handle = sort_trade_frame(handle)
+    handle[quantity_col] = pd.to_numeric(handle[quantity_col], errors="coerce").fillna(0)
+    handle[price_col] = pd.to_numeric(handle[price_col], errors="coerce").fillna(0)
+    handle[fees_col] = pd.to_numeric(handle[fees_col], errors="coerce").fillna(0)
+
+    return handle, {
+        "date_col": date_col,
+        "quantity_col": quantity_col,
+        "price_col": price_col,
+        "symbol_col": symbol_col,
+        "state_col": state_col,
+        "side_col": side_col,
+        "fees_col": fees_col,
+    }
+
+
+def build_buy_event(frame_row, event_id, symbol_col, price_col, quantity_col):
+    return {
+        "event_id": event_id,
+        "symbol": frame_row[symbol_col],
+        "order_id": frame_row.get("order_id", ""),
+        "trade_timestamp": frame_row["trade_timestamp"],
+        "row_sequence": frame_row["row_sequence"],
+        "price": float(frame_row[price_col]),
+        "quantity": float(frame_row[quantity_col]),
+        "open_qty": float(frame_row[quantity_col]),
+        "wash_reserved_qty": 0.0,
+    }
+
+
+def allocate_sale_to_open_lots(symbol_lots, buy_events, sale_qty, sale_price, fee_amount):
+    remaining_to_sell = sale_qty
+    fee_per_share = fee_amount / sale_qty if sale_qty else 0.0
+    sale_net_per_share = sale_price - fee_per_share
+    matched_cost_basis = 0.0
+    loss_segments = []
+
+    while remaining_to_sell > EPSILON and symbol_lots:
+        lot = symbol_lots[0]
+        used_qty = min(remaining_to_sell, lot["open_qty"])
+        cost_per_share = lot["price"]
+        matched_cost_basis += used_qty * cost_per_share
+
+        if cost_per_share > sale_net_per_share + EPSILON:
+            loss_segments.append(
+                {
+                    "source_buy_event_id": lot["buy_event_id"],
+                    "qty": used_qty,
+                    "cost_per_share": cost_per_share,
+                    "sale_net_per_share": sale_net_per_share,
+                    "loss_per_share": cost_per_share - sale_net_per_share,
+                }
+            )
+
+        lot["open_qty"] -= used_qty
+        remaining_to_sell -= used_qty
+        buy_events[lot["buy_event_id"]]["open_qty"] = lot["open_qty"]
+
+        if lot["open_qty"] <= EPSILON:
+            symbol_lots.pop(0)
+
+    return matched_cost_basis, loss_segments
+
+
+def eligible_replacement_buy_ids(buy_events, symbol, sale_timestamp, sale_row_sequence):
+    replacement_window_start = sale_timestamp - timedelta(days=30)
+    replacement_window_end = sale_timestamp + timedelta(days=30)
+    eligible = []
+
+    for event_id, event in buy_events.items():
+        if event["symbol"] != symbol:
+            continue
+        if not replacement_window_start <= event["trade_timestamp"] <= replacement_window_end:
+            continue
+        if event["trade_timestamp"] < sale_timestamp:
+            eligible.append(event_id)
+            continue
+        if event["trade_timestamp"] == sale_timestamp and event["row_sequence"] <= sale_row_sequence:
+            continue
+        eligible.append(event_id)
+
+    eligible.sort(key=lambda event_id: (buy_events[event_id]["trade_timestamp"], buy_events[event_id]["row_sequence"]))
+    return eligible
+
+
+def allocate_wash_sale_matches(row, filled, buy_events, sale_qty, sale_price, fees_col, loss_segments):
+    sale_timestamp = row["trade_timestamp"]
+    eligible_buy_ids = eligible_replacement_buy_ids(
+        buy_events,
+        row["symbol"],
+        sale_timestamp,
+        row["row_sequence"],
+    )
+
+    matched_wash_qty = 0.0
+    disallowed_loss_amount = 0.0
+    replacement_before_qty = 0.0
+    replacement_after_qty = 0.0
+    replacement_dates = set()
+    sale_matches = []
+
+    for segment in loss_segments:
+        segment_remaining = segment["qty"]
+        if segment_remaining <= EPSILON:
+            continue
+
+        for event_id in eligible_buy_ids:
+            if segment_remaining <= EPSILON:
+                break
+
+            event = buy_events[event_id]
+            unreserved_qty = max(event["quantity"] - event["wash_reserved_qty"], 0.0)
+            if unreserved_qty <= EPSILON:
+                continue
+
+            if event["trade_timestamp"] < sale_timestamp:
+                available_qty = min(event["open_qty"], unreserved_qty)
+            else:
+                available_qty = unreserved_qty
+
+            if available_qty <= EPSILON:
+                continue
+
+            matched_qty = min(segment_remaining, available_qty)
+            if matched_qty <= EPSILON:
+                continue
+
+            event["wash_reserved_qty"] += matched_qty
+            segment_remaining -= matched_qty
+            matched_wash_qty += matched_qty
+
+            matched_loss = matched_qty * segment["loss_per_share"]
+            disallowed_loss_amount += matched_loss
+
+            if event["trade_timestamp"] < sale_timestamp:
+                replacement_before_qty += matched_qty
+                replacement_side = "before"
+            else:
+                replacement_after_qty += matched_qty
+                replacement_side = "after"
+            replacement_dates.add(event["trade_timestamp"].date().isoformat())
+
+            source_buy = filled.iloc[segment["source_buy_event_id"]]
+            sale_matches.append(
+                {
+                    "symbol": row["symbol"],
+                    "loss_sale_order_id": row.get("order_id", ""),
+                    "loss_sale_date": sale_timestamp.date().isoformat(),
+                    "loss_sale_timestamp": sale_timestamp.isoformat(),
+                    "loss_sale_quantity": sale_qty,
+                    "loss_sale_price": sale_price,
+                    "loss_sale_fees": float(row[fees_col]),
+                    "source_buy_order_id": source_buy.get("order_id", ""),
+                    "source_buy_date": buy_events[segment["source_buy_event_id"]]["trade_timestamp"].date().isoformat(),
+                    "source_buy_cost_per_share": segment["cost_per_share"],
+                    "replacement_buy_order_id": event["order_id"],
+                    "replacement_buy_date": event["trade_timestamp"].date().isoformat(),
+                    "replacement_buy_timestamp": event["trade_timestamp"].isoformat(),
+                    "replacement_buy_price": event["price"],
+                    "matched_quantity": matched_qty,
+                    "loss_per_share": segment["loss_per_share"],
+                    "disallowed_loss_amount": matched_loss,
+                    "replacement_side": replacement_side,
+                    "warning": "Estimate based on this account export only. Review before filing taxes.",
+                }
+            )
+
+    return {
+        "matched_wash_qty": matched_wash_qty,
+        "disallowed_loss_amount": disallowed_loss_amount,
+        "replacement_before_qty": replacement_before_qty,
+        "replacement_after_qty": replacement_after_qty,
+        "replacement_dates": replacement_dates,
+        "sale_matches": sale_matches,
+    }
+
+
+def profit_extractor(csv_val, filename):
     print("What is your tax multiplier -default 0.25 (25%) ?")
     tax_multiplier = ""
     try:
         input = raw_input
         tax_multiplier = float(input().strip())
-    except:
+    except Exception:
         pass
     if not tax_multiplier:
         tax_multiplier = 0.25
 
-    profit_filename = filename.split('.')[0] + "_profit.csv"
+    profit_filename = filename.split(".")[0] + "_profit.csv"
 
-    handle_raw = pd.read_csv(filename)
+    handle_raw, cols = load_trade_frame(filename)
     handle = handle_raw.copy()
-    # convert date to date item and sort from oldest to newest
-    handle['last_transaction_at'] = pd.to_datetime(handle.last_transaction_at)
-    handle = handle.sort_values('last_transaction_at')
-    handle['processed'] = 0
-    handle['used'] = False
-    handle['Profit'] = 0
-    handle['Wash Sale'] = 0
-    handle['Tax'] = 0
+    quantity_col = cols["quantity_col"]
+    price_col = cols["price_col"]
+    symbol_col = cols["symbol_col"]
+    state_col = cols["state_col"]
+    side_col = cols["side_col"]
+    fees_col = cols["fees_col"]
+    handle["processed"] = 0
+    handle["used"] = False
+    handle["Profit"] = 0
+    handle["Wash Sale"] = 0
+    handle["Tax"] = 0
 
-    # iterate over the rows, find a sale, find previous buys of same stock
-    # for each sale, consider the oldest available buy first
-    # mark used buys so they are not counted twice
     for index, row in handle.iterrows():
-        if row.state == 'filled' and row.side == 'sell':
-            previous_buys = handle.loc[(handle['symbol'] == row.symbol) &
-                                       (handle['last_transaction_at'] <= row['last_transaction_at']) &
-                                       (handle['state'] == 'filled') &
-                                       (handle['side'] == 'buy') &
-                                       (handle['used'] == False)
-                                       ]
-            # if no previous for a given sell, missing transaction(s)
+        if row[state_col] == "filled" and row[side_col] == "sell":
+            previous_buys = handle.loc[
+                (handle[symbol_col] == row[symbol_col])
+                & (handle["trade_timestamp"] <= row["trade_timestamp"])
+                & (handle[state_col] == "filled")
+                & (handle[side_col] == "buy")
+                & (handle["used"] == False)
+            ]
             if previous_buys.empty:
                 print(index, "missing previous transaction, skipped")
-                handle.loc[index, 'Profit'] = 'missing transaction'
+                handle.loc[index, "Profit"] = "missing transaction"
                 continue
 
-            # check for wash sales
-            # TODO to properly track wash sales, the entire script has to be rewritten
-            # If shares are sold in a wash sale and repurchased, the previous loss is not deductible and has to be added to the new purchase price
-            # This can get quite complex if share from different previous trades were sold and repurchased
-            # Additionally, the timing for long-term keeps on counting on those shares
-            # this implementation only covers single wash sales and adds the disallowed loss in a new column 'Wash Sale'
-            ws_buys = handle.loc[(handle['symbol'] == row.symbol) &
-                                 (handle['last_transaction_at'] >= row['last_transaction_at']) &
-                                 (handle['last_transaction_at'] <= row['last_transaction_at'] + timedelta(days=30)) &
-                                 (handle['state'] == 'filled') &
-                                 (handle['side'] == 'buy') &
-                                 (handle['used'] == False)
-                                 ]
+            ws_buys = handle.loc[
+                (handle[symbol_col] == row[symbol_col])
+                & (handle["trade_timestamp"] >= row["trade_timestamp"])
+                & (handle["trade_timestamp"] <= row["trade_timestamp"] + timedelta(days=30))
+                & (handle[state_col] == "filled")
+                & (handle[side_col] == "buy")
+                & (handle["used"] == False)
+            ]
 
             ws_count = 0
             if not ws_buys.empty:
-                # calculate
-                # find previous buys to calculate loss
-                print('found')
-                for buy_index, buy in ws_buys.iterrows():
-                    ws_count += buy.cumulative_quantity
+                for _, buy in ws_buys.iterrows():
+                    ws_count += buy[quantity_col]
 
-            # for each buy, compare the share number to the sold, and loop until oll sold
-            # shares have a corresponding buy, and store the number of processed stocks in buys
-            # so they are not counted twice
-            # I saw some difference between cumulative_quantity and quantity columns, used cumulative_quantity
-            number = row.cumulative_quantity
+            number = row[quantity_col]
             buy_list = []
 
             for buy_index, buy in previous_buys.iterrows():
-                available = buy.cumulative_quantity - buy.processed
+                available = buy[quantity_col] - buy.processed
                 if available > number:
-                    handle.loc[buy_index, 'processed'] = number
-                    buy_list.append((number, float(buy.average_price)))
+                    handle.loc[buy_index, "processed"] = number
+                    buy_list.append((number, float(buy[price_col])))
                     break
-                elif available == number:
-                    handle.loc[buy_index, 'processed'] = number
-                    handle.loc[buy_index, 'used'] = True
-                    buy_list.append((number, float(buy.average_price)))
+                if available == number:
+                    handle.loc[buy_index, "processed"] = number
+                    handle.loc[buy_index, "used"] = True
+                    buy_list.append((number, float(buy[price_col])))
                     break
-                elif available < number:
+                if available < number:
                     total_used = buy.processed + available
-                    # if available sell is less then total number sold, use all the bought share from this transaction
-                    assert total_used == buy.cumulative_quantity
-                    handle.loc[buy_index, 'processed'] = total_used
-                    handle.loc[buy_index, 'used'] = True
-                    buy_list.append((available, float(buy.average_price)))
+                    assert total_used == buy[quantity_col]
+                    handle.loc[buy_index, "processed"] = total_used
+                    handle.loc[buy_index, "used"] = True
+                    buy_list.append((available, float(buy[price_col])))
                     number = number - available
-            total_sell = float(row.cumulative_quantity) * float(row.average_price)
+            total_sell = float(row[quantity_col]) * float(row[price_col])
             total_buy = 0
             total_ws = 0
             ws_count_temp = ws_count
             for q, p in buy_list:
-                total_buy += float(q)*float(p)
-                for i in range(0, q):
+                total_buy += float(q) * float(p)
+                for _ in range(0, int(q)):
                     if ws_count_temp > 0:
-                        amount = p-float(row.average_price)
+                        amount = p - float(row[price_col])
                         if amount > 0:
                             total_ws += amount
                             ws_count_temp -= 1
 
-            if total_ws > 0:  # add fees
-                total_ws += float(row.fees) / float(row.cumulative_quantity) * (ws_count - ws_count_temp)
+            if total_ws > 0:
+                total_ws += float(row[fees_col]) / float(row[quantity_col]) * (ws_count - ws_count_temp)
 
-            profit = total_sell - total_buy - float(row.fees)
-            handle.loc[index, 'Profit'] = profit
-            handle.loc[index, 'Wash Sale'] = total_ws
+            profit = total_sell - total_buy - float(row[fees_col])
+            handle.loc[index, "Profit"] = profit
+            handle.loc[index, "Wash Sale"] = total_ws
             if profit > 0:
-                handle.loc[index, 'Tax'] = profit * tax_multiplier
+                handle.loc[index, "Tax"] = profit * tax_multiplier
 
-    handle_raw['profit'] = handle['Profit']
-    handle_raw['Wash Sale'] = handle['Wash Sale']
-    tax_row = "Tax("+str(tax_multiplier)+")"
-    handle_raw[tax_row] = handle['Tax']
-    # save the profit CSV
+    handle_raw["profit"] = handle["Profit"]
+    handle_raw["Wash Sale"] = handle["Wash Sale"]
+    tax_row = "Tax(" + str(tax_multiplier) + ")"
+    handle_raw[tax_row] = handle["Tax"]
     handle_raw.to_csv(profit_filename)
+
+
+def export_wash_sale_candidates(filename):
+    handle, cols = load_trade_frame(filename)
+    quantity_col = cols["quantity_col"]
+    price_col = cols["price_col"]
+    state_col = cols["state_col"]
+    side_col = cols["side_col"]
+    fees_col = cols["fees_col"]
+
+    filled = sort_trade_frame(handle.loc[handle[state_col] == "filled"].copy())
+    buy_events = {}
+    for idx, row in filled.iterrows():
+        if row[side_col] == "buy":
+            buy_events[idx] = build_buy_event(row, idx, "symbol", price_col, quantity_col)
+
+    summary_rows = []
+    detail_rows = []
+    open_lots = {}
+
+    for idx, row in filled.iterrows():
+        symbol = row["symbol"]
+        open_lots.setdefault(symbol, [])
+
+        if row[side_col] == "buy":
+            open_lots[symbol].append(
+                {
+                    "buy_event_id": idx,
+                    "price": float(row[price_col]),
+                    "open_qty": float(row[quantity_col]),
+                }
+            )
+            continue
+
+        if row[side_col] != "sell":
+            continue
+
+        sale_qty = float(row[quantity_col])
+        sale_price = float(row[price_col])
+        sale_fees = float(row[fees_col])
+        if sale_qty <= EPSILON:
+            continue
+
+        matched_cost_basis, loss_segments = allocate_sale_to_open_lots(
+            open_lots[symbol],
+            buy_events,
+            sale_qty,
+            sale_price,
+            sale_fees,
+        )
+
+        if not loss_segments:
+            continue
+
+        total_loss_amount = sum(segment["qty"] * segment["loss_per_share"] for segment in loss_segments)
+        wash_match = allocate_wash_sale_matches(
+            row,
+            filled,
+            buy_events,
+            sale_qty,
+            sale_price,
+            fees_col,
+            loss_segments,
+        )
+
+        if wash_match["matched_wash_qty"] <= EPSILON:
+            continue
+
+        proceeds = sale_qty * sale_price - sale_fees
+        summary_rows.append(
+            {
+                "symbol": symbol,
+                "loss_sale_order_id": row.get("order_id", ""),
+                "loss_sale_date": row["trade_timestamp"].date().isoformat(),
+                "loss_sale_timestamp": row["trade_timestamp"].isoformat(),
+                "sale_quantity": sale_qty,
+                "sale_price": sale_price,
+                "sale_fees": sale_fees,
+                "sale_proceeds_net": proceeds,
+                "matched_cost_basis_fifo": matched_cost_basis,
+                "realized_loss_total_estimate": -total_loss_amount,
+                "wash_sale_matched_quantity": wash_match["matched_wash_qty"],
+                "replacement_buy_quantity_30d_before": wash_match["replacement_before_qty"],
+                "replacement_buy_quantity_30d_after": wash_match["replacement_after_qty"],
+                "disallowed_loss_estimate": -wash_match["disallowed_loss_amount"],
+                "allowed_loss_estimate": -(total_loss_amount - wash_match["disallowed_loss_amount"]),
+                "replacement_buy_dates": ", ".join(sorted(wash_match["replacement_dates"])),
+                "match_count": len(wash_match["sale_matches"]),
+                "warning": "Estimate based on this account export only. Review before filing taxes.",
+            }
+        )
+        detail_rows.extend(wash_match["sale_matches"])
+
+    output_filename = os.path.splitext(filename)[0] + "_wash_sale_candidates.csv"
+    detail_filename = os.path.splitext(filename)[0] + "_wash_sale_lot_matches.csv"
+    pd.DataFrame(summary_rows).to_csv(output_filename, index=False)
+    pd.DataFrame(detail_rows).to_csv(detail_filename, index=False)
+    print("Wrote {} rows to {}.".format(len(summary_rows), output_filename))
+    print("Wrote {} rows to {}.".format(len(detail_rows), detail_filename))
+    return output_filename

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 pandas>=0.17.0
 python-dotenv>=0.8.2
 uuid
+browser-cookie3


### PR DESCRIPTION
## Summary
- add stock and options holdings export scripts based on the Robinhood positions endpoints
- add a single export-all.py command to export trade history and current holdings in one authenticated run
- document setup, credentials, outputs, and the difference between holdings and order history

## Changes
- add csv-holdings-export.py for current stock holdings
- add csv-options-holdings-export.py for current options holdings with contract metadata enrichment
- add exporters.py to share export logic across the CLI scripts
- add export-all.py as a wrapper command for the full account snapshot
- update README.md with usage instructions, environment variables, wrapper command docs, and a holdings vs history explanation
- simplify the existing history and holdings scripts into thin wrappers over the shared exporter functions

## Test plan
- run python3 -m py_compile exporters.py export-all.py csv-export.py csv-options-export.py csv-holdings-export.py csv-options-holdings-export.py login_data.py Robinhood.py profit_extractor.py
- run python3 export-all.py --help
- run python3 csv-export.py --help
- run python3 csv-options-export.py --help
- live Robinhood API execution not run in this environment